### PR TITLE
[Extend] Add Character -1

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -77,8 +77,8 @@ erDiagram
   DateTime created_at
   DateTime deleted_at "nullable"
 }
-"Character_Experience" {
-  String character_id FK
+"Character_Snapshot_Experience" {
+  String character_snapshot_id FK
   String experience_id FK
   DateTime created_at
   DateTime deleted_at "nullable"
@@ -143,8 +143,8 @@ erDiagram
   DateTime deleted_at "nullable"
   String member_id FK "nullable"
 }
-"Character_Experience" }o--|| "Character" : character
-"Character_Experience" }o--|| "Experience" : experience
+"Character_Snapshot_Experience" }o--|| "Character_Snapshot" : character_snapshot
+"Character_Snapshot_Experience" }o--|| "Experience" : experience
 "Source" }o--|| "Character" : character
 "Character_Snapshot" }o--|| "Character" : character
 "Character_Last_Snapshot" |o--|| "Character" : character
@@ -164,7 +164,7 @@ erDiagram
   - `id`: PK
   - `member_id`: 가입된 사용자가 경력을 입력할 수 있다.
   - `company_name`: 
-  - `position`: 직군을 입력한다.
+  - `position`: 직군을 입력한다. 
   - `start_date`: 근무 시작 날짜. 월까지 입력한다.
   - `end_date`: 근무 종료 날짜. 월까지 입력하며, 현재 재직 중일 경우 null이다.
   - `description`: 경력에 대한 설명. 업문 내용 등 사용자가 입력하고 싶은 것들을 적으며, 비워둘 수 있다.
@@ -172,11 +172,11 @@ erDiagram
   - `created_at`: 경력을 최초 입력후 저장한 시간.
   - `deleted_at`: 경력을 삭제한 경우.
 
-### `Character_Experience`
-캐릭터의 학습에 사용된 경력 사항들을 저장한다.
+### `Character_Snapshot_Experience`
+캐릭터의 학습에 사용된 경력 사항들을 저장한다. 캐릭터 스냅샷과 다대다 관계를 가진다.
 
 **Properties**
-  - `character_id`: Character FK
+  - `character_snapshot_id`: Character_Snapshot FK
   - `experience_id`: Experience FK
   - `created_at`: 관계 생성 시간
   - `deleted_at`: 관계 삭제 시간
@@ -224,16 +224,16 @@ erDiagram
 캐릭터의 마지막 스냅샷
 
 **Properties**
-  - `character_id`: 
-  - `character_snapshot_id`: 
+  - `character_id`: Character FK
+  - `character_snapshot_id`: Character_Snapshot FK
 
 ### `Character_Personality`
 캐릭터의 성격 유형
 하나의 캐릭터는 여러개의 성격으로 지정될 수 있으며, 하나의 성격은 여러개의 캐릭터가 가지고 있을수 있다.
 
 **Properties**
-  - `character_id`: 
-  - `personality_id`: 
+  - `character_id`: Character FK
+  - `personality_id`: Personality FK
   - `created_at`: 캐릭터와 성격이 관계 생성 시점
   - `deleted_at`: 캐릭터와 성격의 관계가 해제된 시점
 

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -103,6 +103,7 @@ erDiagram
   String id PK
   String character_id FK
   String nickname
+  String position
   String image "nullable"
   DateTime created_at
 }
@@ -223,6 +224,7 @@ erDiagram
   - `nickname`: 사용자의 이름, 본명을 사용하는 것이 권장되나 강제성은 없다.
 =======
   - `nickname`: 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
+  - `position`: 캐릭터의 직군. 프론트엔드, 백엔드 등을 입력할 수 있다.
   - `image`: 캐릭터 프로필 이미지. s3 url을 저장한다.
 >>>>>>> c3bc7e4 (feat: Character에 프로필 이미지 칼럼 스키마 정의)
   - `created_at`: 스냅샷 생성 시점

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -103,6 +103,7 @@ erDiagram
   String id PK
   String character_id FK
   String nickname
+  String image "nullable"
   DateTime created_at
 }
 "Character_Last_Snapshot" {
@@ -156,6 +157,7 @@ erDiagram
 "Chat" }o--o| "Character" : character
 ```
 
+<<<<<<< HEAD
 ### `Experience`
 `Member`의 경력사항을 나타낸다.
 
@@ -181,6 +183,8 @@ erDiagram
   - `created_at`: 관계 생성 시간
   - `deleted_at`: 관계 삭제 시간
 
+=======
+>>>>>>> c3bc7e4 (feat: Character에 프로필 이미지 칼럼 스키마 정의)
 ### `Source`
 캐릭터 학습에 필요한 자료들
 자기소개서, 포트폴리오, 이력서와 같은 파일
@@ -215,7 +219,12 @@ erDiagram
 **Properties**
   - `id`: PK
   - `character_id`: 스냅샷이 참조하는 캐릭터 ID
+<<<<<<< HEAD
   - `nickname`: 사용자의 이름, 본명을 사용하는 것이 권장되나 강제성은 없다.
+=======
+  - `nickname`: 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
+  - `image`: 캐릭터 프로필 이미지. s3 url을 저장한다.
+>>>>>>> c3bc7e4 (feat: Character에 프로필 이미지 칼럼 스키마 정의)
   - `created_at`: 스냅샷 생성 시점
 
 ### `Character_Last_Snapshot`

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -158,7 +158,6 @@ erDiagram
 "Chat" }o--o| "Character" : character
 ```
 
-<<<<<<< HEAD
 ### `Experience`
 `Member`의 경력사항을 나타낸다.
 
@@ -184,8 +183,6 @@ erDiagram
   - `created_at`: 관계 생성 시간
   - `deleted_at`: 관계 삭제 시간
 
-=======
->>>>>>> c3bc7e4 (feat: Character에 프로필 이미지 칼럼 스키마 정의)
 ### `Source`
 캐릭터 학습에 필요한 자료들
 자기소개서, 포트폴리오, 이력서와 같은 파일
@@ -220,13 +217,9 @@ erDiagram
 **Properties**
   - `id`: PK
   - `character_id`: 스냅샷이 참조하는 캐릭터 ID
-<<<<<<< HEAD
-  - `nickname`: 사용자의 이름, 본명을 사용하는 것이 권장되나 강제성은 없다.
-=======
   - `nickname`: 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
   - `position`: 캐릭터의 직군. 프론트엔드, 백엔드 등을 입력할 수 있다.
   - `image`: 캐릭터 프로필 이미지. s3 url을 저장한다.
->>>>>>> c3bc7e4 (feat: Character에 프로필 이미지 칼럼 스키마 정의)
   - `created_at`: 스냅샷 생성 시점
 
 ### `Character_Last_Snapshot`

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -78,7 +78,6 @@ erDiagram
   DateTime deleted_at "nullable"
 }
 "Character_Experience" {
-  String id PK
   String character_id FK
   String experience_id FK
   DateTime created_at
@@ -177,7 +176,6 @@ erDiagram
 캐릭터의 학습에 사용된 경력 사항들을 저장한다.
 
 **Properties**
-  - `id`: PK
   - `character_id`: Character FK
   - `experience_id`: Experience FK
   - `created_at`: 관계 생성 시간

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,7 +69,6 @@ model Experience {
 /// 캐릭터의 학습에 사용된 경력 사항들을 저장한다.
 /// @namespace Character
 model Character_Experience {
-  id            String    @id @db.Uuid /// PK
   character_id  String    @db.Uuid /// Character FK
   experience_id String    @db.Uuid /// Experience FK
   created_at    DateTime  @default(now()) @db.Timestamptz /// 관계 생성 시간

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,7 +140,8 @@ model Character {
 model Character_Snapshot {
   id           String   @id @db.Uuid /// PK
   character_id String   @db.Uuid /// 스냅샷이 참조하는 캐릭터 ID
-  nickname     String /// 사용자의 이름, 본명을 사용하는 것이 권장되나 강제성은 없다.
+  nickname     String /// 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
+  image        String? /// 캐릭터 프로필 이미지. s3 url을 저장한다.
   created_at   DateTime @db.Timestamptz /// 스냅샷 생성 시점
 
   character     Character                @relation(fields: [character_id], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,7 @@ model Character_Snapshot {
   id           String   @id @db.Uuid /// PK
   character_id String   @db.Uuid /// 스냅샷이 참조하는 캐릭터 ID
   nickname     String /// 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
+  position     String /// 캐릭터의 직군. 프론트엔드, 백엔드 등을 입력할 수 있다.
   image        String? /// 캐릭터 프로필 이미지. s3 url을 저장한다.
   created_at   DateTime @db.Timestamptz /// 스냅샷 생성 시점
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,7 +54,7 @@ model Experience {
   id           String    @id @db.Uuid /// PK
   member_id    String    @db.Uuid /// 가입된 사용자가 경력을 입력할 수 있다.
   company_name String
-  position     String /// 직군을 입력한다.
+  position     String /// 직군을 입력한다. 
   start_date   String /// 근무 시작 날짜. 월까지 입력한다.
   end_date     String? /// 근무 종료 날짜. 월까지 입력하며, 현재 재직 중일 경우 null이다.
   description  String? /// 경력에 대한 설명. 업문 내용 등 사용자가 입력하고 싶은 것들을 적으며, 비워둘 수 있다.
@@ -62,22 +62,22 @@ model Experience {
   created_at   DateTime  @db.Timestamptz /// 경력을 최초 입력후 저장한 시간.
   deleted_at   DateTime? @db.Timestamptz /// 경력을 삭제한 경우.
 
-  memer                 Member                 @relation(fields: [member_id], references: [id])
-  character_experiences Character_Experience[]
+  memer                          Member                          @relation(fields: [member_id], references: [id])
+  character_snapshot_experiences Character_Snapshot_Experience[]
 }
 
-/// 캐릭터의 학습에 사용된 경력 사항들을 저장한다.
+/// 캐릭터의 학습에 사용된 경력 사항들을 저장한다. 캐릭터 스냅샷과 다대다 관계를 가진다.
 /// @namespace Character
-model Character_Experience {
-  character_id  String    @db.Uuid /// Character FK
-  experience_id String    @db.Uuid /// Experience FK
-  created_at    DateTime  @default(now()) @db.Timestamptz /// 관계 생성 시간
-  deleted_at    DateTime? @db.Timestamptz /// 관계 삭제 시간
+model Character_Snapshot_Experience {
+  character_snapshot_id String    @db.Uuid /// Character_Snapshot FK
+  experience_id         String    @db.Uuid /// Experience FK
+  created_at            DateTime  @default(now()) @db.Timestamptz /// 관계 생성 시간
+  deleted_at            DateTime? @db.Timestamptz /// 관계 삭제 시간
 
-  character  Character  @relation(fields: [character_id], references: [id])
-  experience Experience @relation(fields: [experience_id], references: [id])
+  character_snapshot Character_Snapshot @relation(fields: [character_snapshot_id], references: [id])
+  experience         Experience         @relation(fields: [experience_id], references: [id])
 
-  @@unique([character_id, experience_id]) /// Character와 Experience의 조합이 유일해야 함
+  @@unique([character_snapshot_id, experience_id]) /// Character와 Experience의 조합이 유일해야 함
 }
 
 /// OAuth 연동 정보를 저장한다.
@@ -127,7 +127,6 @@ model Character {
   chats                  Chat[] /// 캐릭터와 대화한 기록
   sources                Source[] /// 캐릭터 생성에 사용된 소스
   character_personalites Character_Personality[] /// 캐릭터 생성에 사용된 성격
-  character_experiences  Character_Experience[] /// 캐릭터 생성에 사용된 경험
 
   /// 스냅샷들
   snapshots     Character_Snapshot[]
@@ -144,15 +143,16 @@ model Character_Snapshot {
   image        String? /// 캐릭터 프로필 이미지. s3 url을 저장한다.
   created_at   DateTime @db.Timestamptz /// 스냅샷 생성 시점
 
-  character     Character                @relation(fields: [character_id], references: [id])
-  last_snapshot Character_Last_Snapshot?
+  character                      Character                       @relation(fields: [character_id], references: [id])
+  last_snapshot                  Character_Last_Snapshot?
+  character_snapshot_experiences Character_Snapshot_Experience[]
 }
 
 /// 캐릭터의 마지막 스냅샷
 /// @namespace Character
 model Character_Last_Snapshot {
-  character_id          String @id @db.Uuid
-  character_snapshot_id String @db.Uuid
+  character_id          String @id @db.Uuid /// Character FK
+  character_snapshot_id String @db.Uuid /// Character_Snapshot FK
 
   character Character          @relation(fields: [character_id], references: [id])
   snapshot  Character_Snapshot @relation(fields: [character_snapshot_id], references: [id])
@@ -164,8 +164,8 @@ model Character_Last_Snapshot {
 /// 하나의 캐릭터는 여러개의 성격으로 지정될 수 있으며, 하나의 성격은 여러개의 캐릭터가 가지고 있을수 있다.
 /// @namespace Character
 model Character_Personality {
-  character_id   String    @db.Uuid
-  personality_id String    @db.Uuid
+  character_id   String    @db.Uuid /// Character FK
+  personality_id String    @db.Uuid /// Personality FK
   created_at     DateTime  @db.Timestamptz /// 캐릭터와 성격이 관계 생성 시점
   deleted_at     DateTime? @db.Timestamptz /// 캐릭터와 성격의 관계가 해제된 시점
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -10,7 +10,7 @@ export class AuthController {
   /**
    * AccessToken과 RefreshToken을 재발급 한다.
    */
-  @core.TypedRoute.Get('refresh')
+  @core.TypedRoute.Post('refresh')
   async refresh(
     @core.TypedBody() body: Auth.RefreshRequest,
   ): Promise<Auth.LoginResponse> {

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -1,4 +1,4 @@
-import core, { TypedBody, TypedParam, TypedQuery } from '@nestia/core';
+import core from '@nestia/core';
 import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { User } from 'src/decorators/user.decorator';

--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -1,27 +1,29 @@
 import { tags } from 'typia';
+import { Member } from './member.interface';
+import { Provider } from './provider.interface';
 
 export namespace Auth {
   export interface RefreshRequest {
-    refreshToken: string;
+    refreshToken: string & tags.MinLength<1>;
   }
 
   export interface LoginRequest {
-    code: string;
+    code: string & tags.MinLength<1>;
   }
 
   export interface LoginResponse {
-    id: string & tags.Format<'uuid'>;
-    name: string;
-    accessToken: string;
-    refreshToken: string;
+    id: Member['id'];
+    name: Member['name'];
+    accessToken: string & tags.MinLength<1>;
+    refreshToken: string & tags.MinLength<1>;
   }
 
   export interface CommonAuthorizationResponse {
-    uid: string;
-    name: string;
+    uid: Provider['uid'];
+    name: Member['name'];
     email: string & tags.Format<'email'>;
-    accessToken: string;
-    refreshToken: string;
-    type: 'google' | 'github' | 'linkedin';
+    accessToken: string & tags.MinLength<1>;
+    refreshToken: Provider['password'];
+    type: Provider['type'];
   }
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -4,8 +4,9 @@ import { Personality } from './personalities.interface';
 
 export interface Character {
   id: string & tags.Format<'uuid'>;
-  memberId: string;
+  memberId: string & tags.Format<'uuid'>;
   nickname: string & tags.MinLength<1>;
+  image: (string & tags.MinLength<1>) | null;
   isPublic: boolean;
   createdAt: string & tags.Format<'date-time'>;
   deletedAt: string & tags.Format<'date-time'>;
@@ -14,6 +15,7 @@ export interface Character {
 export namespace Character {
   export interface CreateRequest
     extends Pick<Character, 'nickname' | 'isPublic'> {
+    image?: Character['image'];
     personalities: Personality['id'][] & tags.MinItems<1>;
   }
 
@@ -22,7 +24,7 @@ export namespace Character {
   export interface GetResponse
     extends Pick<
       Character,
-      'id' | 'memberId' | 'nickname' | 'isPublic' | 'createdAt'
+      'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'
     > {
     personality: Personality['keyword'][];
   }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -1,6 +1,7 @@
 import { PaginationUtil } from 'src/util/pagination.util';
 import { tags } from 'typia';
 import { Personality } from './personalities.interface';
+import { Experience } from './experiences.interface';
 
 export interface Character {
   id: string & tags.Format<'uuid'>;
@@ -17,7 +18,8 @@ export namespace Character {
   export interface CreateRequest
     extends Pick<Character, 'nickname' | 'isPublic' | 'position'> {
     image?: Character['image'];
-    personalities: Personality['id'][] & tags.MinItems<1>;
+    personalities: Array<Personality['id']> & tags.MinItems<1>;
+    experiences: Array<Experience['id']> & tags.MinItems<1>;
   }
 
   export interface CreateResponse extends Pick<Character, 'id'> {}
@@ -33,7 +35,7 @@ export namespace Character {
       | 'isPublic'
       | 'createdAt'
     > {
-    personality: Personality['keyword'][];
+    personality: Array<Personality['keyword']>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -1,5 +1,6 @@
 import { PaginationUtil } from 'src/util/pagination.util';
 import { tags } from 'typia';
+import { Personality } from './personalities.interface';
 
 export interface Character {
   id: string & tags.Format<'uuid'>;
@@ -12,7 +13,9 @@ export interface Character {
 
 export namespace Character {
   export interface CreateRequest
-    extends Pick<Character, 'nickname' | 'isPublic'> {}
+    extends Pick<Character, 'nickname' | 'isPublic'> {
+    personalities: Personality['id'][] & tags.MinItems<1>;
+  }
 
   export interface CreateResponse extends Pick<Character, 'id'> {}
 
@@ -20,7 +23,9 @@ export namespace Character {
     extends Pick<
       Character,
       'id' | 'memberId' | 'nickname' | 'isPublic' | 'createdAt'
-    > {}
+    > {
+    personality: Personality['keyword'][];
+  }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}
 

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -1,11 +1,12 @@
 import { PaginationUtil } from 'src/util/pagination.util';
 import { tags } from 'typia';
-import { Personality } from './personalities.interface';
 import { Experience } from './experiences.interface';
+import { Member } from './member.interface';
+import { Personality } from './personalities.interface';
 
 export interface Character {
   id: string & tags.Format<'uuid'>;
-  memberId: string & tags.Format<'uuid'>;
+  memberId: Member['id'];
   nickname: string & tags.MinLength<1>;
   position: string & tags.MinLength<1>;
   image: (string & tags.MinLength<1>) | null;
@@ -15,15 +16,21 @@ export interface Character {
 }
 
 export namespace Character {
+  /**
+   * create
+   */
   export interface CreateRequest
-    extends Pick<Character, 'nickname' | 'isPublic' | 'position'> {
-    image?: Character['image'];
+    extends Pick<Character, 'nickname' | 'isPublic' | 'position'>,
+      Partial<Pick<Character, 'image'>> {
     personalities: Array<Personality['id']> & tags.MinItems<1>;
     experiences: Array<Experience['id']> & tags.MinItems<1>;
   }
 
   export interface CreateResponse extends Pick<Character, 'id'> {}
 
+  /**
+   * get
+   */
   export interface GetResponse
     extends Pick<
       Character,
@@ -35,7 +42,7 @@ export namespace Character {
       | 'isPublic'
       | 'createdAt'
     > {
-    personality: Array<Personality['keyword']>;
+    personalities: Array<Personality['keyword']>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -6,6 +6,7 @@ export interface Character {
   id: string & tags.Format<'uuid'>;
   memberId: string & tags.Format<'uuid'>;
   nickname: string & tags.MinLength<1>;
+  position: string & tags.MinLength<1>;
   image: (string & tags.MinLength<1>) | null;
   isPublic: boolean;
   createdAt: string & tags.Format<'date-time'>;
@@ -14,7 +15,7 @@ export interface Character {
 
 export namespace Character {
   export interface CreateRequest
-    extends Pick<Character, 'nickname' | 'isPublic'> {
+    extends Pick<Character, 'nickname' | 'isPublic' | 'position'> {
     image?: Character['image'];
     personalities: Personality['id'][] & tags.MinItems<1>;
   }
@@ -24,7 +25,13 @@ export namespace Character {
   export interface GetResponse
     extends Pick<
       Character,
-      'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'
+      | 'id'
+      | 'memberId'
+      | 'nickname'
+      | 'position'
+      | 'image'
+      | 'isPublic'
+      | 'createdAt'
     > {
     personality: Personality['keyword'][];
   }

--- a/src/interfaces/experiences.interface.ts
+++ b/src/interfaces/experiences.interface.ts
@@ -5,7 +5,7 @@ export interface Experience {
   companyName: string & tags.MinLength<1>;
   position: string & tags.MinLength<1>;
   startDate: string & tags.Format<'date'>;
-  endDate: string & tags.Format<'date'>;
+  endDate: (string & tags.Format<'date'>) | null;
   description: string | null;
   sequence: number & tags.Minimum<0> & tags.Type<'int64'>;
   createdAt: string & tags.Format<'date-time'>;
@@ -32,15 +32,15 @@ export namespace Experience {
    */
   export interface GetResponse
     extends Pick<
-        Experience,
-        | 'id'
-        | 'companyName'
-        | 'position'
-        | 'description'
-        | 'startDate'
-        | 'sequence'
-      >,
-      Partial<Pick<Experience, 'endDate'>> {}
+      Experience,
+      | 'id'
+      | 'companyName'
+      | 'position'
+      | 'description'
+      | 'startDate'
+      | 'sequence'
+      | 'endDate'
+    > {}
 
   export interface GetAllResponse extends Array<GetResponse> {}
 }

--- a/src/interfaces/experiences.interface.ts
+++ b/src/interfaces/experiences.interface.ts
@@ -13,30 +13,34 @@ export interface Experience {
 }
 
 export namespace Experience {
+  /**
+   * create
+   */
   export interface CreateData
     extends Pick<
-      Experience,
-      'companyName' | 'position' | 'startDate' | 'endDate' | 'sequence'
-    > {
-    description?: Experience['description'];
-  }
+        Experience,
+        'companyName' | 'position' | 'startDate' | 'endDate' | 'sequence'
+      >,
+      Partial<Pick<Experience, 'description'>> {}
 
   export interface CreateRequest {
     experiences: Array<CreateData> & tags.MinItems<1>;
   }
 
+  /**
+   * get
+   */
   export interface GetResponse
     extends Pick<
-      Experience,
-      | 'id'
-      | 'companyName'
-      | 'position'
-      | 'description'
-      | 'startDate'
-      | 'sequence'
-    > {
-    endDate?: Experience['endDate'] | null;
-  }
+        Experience,
+        | 'id'
+        | 'companyName'
+        | 'position'
+        | 'description'
+        | 'startDate'
+        | 'sequence'
+      >,
+      Partial<Pick<Experience, 'endDate'>> {}
 
   export interface GetAllResponse extends Array<GetResponse> {}
 }

--- a/src/interfaces/member.interface.ts
+++ b/src/interfaces/member.interface.ts
@@ -1,0 +1,8 @@
+import { tags } from 'typia';
+
+export interface Member {
+  id: string & tags.Format<'uuid'>;
+  name: string & tags.MinLength<1>;
+  createdAt: string & tags.Format<'date-time'>;
+  deletedAt: string & tags.Format<'date-time'>;
+}

--- a/src/interfaces/personalities.interface.ts
+++ b/src/interfaces/personalities.interface.ts
@@ -9,12 +9,18 @@ export interface Personality {
 }
 
 export namespace Personality {
+  /**
+   * create
+   */
   export interface CreateBulkRequest {
-    keywords: string[] & tags.MinItems<0>;
+    keywords: Array<string> & tags.MinItems<0>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}
 
+  /**
+   * get
+   */
   export interface GetByPageData extends Pick<Personality, 'id' | 'keyword'> {}
 
   export interface GetByPageResonse

--- a/src/interfaces/provider.interface.ts
+++ b/src/interfaces/provider.interface.ts
@@ -1,0 +1,11 @@
+import { tags } from 'typia';
+import { Member } from './member.interface';
+
+export interface Provider {
+  id: string & tags.Format<'uuid'>;
+  memberId: Member['id'];
+  type: ('google' | 'github' | 'linkedin') & tags.MinLength<1>;
+  uid: string & tags.MinLength<1>;
+  password: string & tags.MinLength<1>;
+  created_at: string & tags.Format<'date-time'>;
+}

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -29,6 +29,7 @@ export class CharactersService {
           create: {
             id: snapshotId,
             nickname: input.nickname,
+            position: input.position,
             image: input.image,
             created_at: date,
           },
@@ -69,6 +70,7 @@ export class CharactersService {
             snapshot: {
               select: {
                 nickname: true,
+                position: true,
                 image: true,
                 created_at: true,
               },
@@ -86,7 +88,9 @@ export class CharactersService {
       where: { id, is_public: true },
     });
 
-    if (!character?.last_snapshot?.snapshot) {
+    const snapshot = character?.last_snapshot?.snapshot;
+
+    if (!snapshot) {
       throw new NotFoundException();
     }
 
@@ -97,9 +101,12 @@ export class CharactersService {
       id: character.id,
       memberId: character.member_id,
       isPublic: character.is_public,
-      nickname: character.last_snapshot.snapshot.nickname,
-      image: character.last_snapshot.snapshot.image,
-      createdAt: character.last_snapshot.snapshot.created_at.toISOString(),
+
+      nickname: snapshot.nickname,
+      position: snapshot.position,
+      image: snapshot.image,
+      createdAt: snapshot.created_at.toISOString(),
+
       personality: character.characterPersonalites.map(
         (el) => el.personality.keyword,
       ),

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -29,6 +29,7 @@ export class CharactersService {
           create: {
             id: snapshotId,
             nickname: input.nickname,
+            image: input.image,
             created_at: date,
           },
         },
@@ -63,20 +64,21 @@ export class CharactersService {
         id: true,
         member_id: true,
         is_public: true,
-        characterPersonalites: {
-          select: {
-            personality: {
-              select: { keyword: true },
-            },
-          },
-        },
         last_snapshot: {
           select: {
             snapshot: {
               select: {
                 nickname: true,
+                image: true,
                 created_at: true,
               },
+            },
+          },
+        },
+        characterPersonalites: {
+          select: {
+            personality: {
+              select: { keyword: true },
             },
           },
         },
@@ -96,6 +98,7 @@ export class CharactersService {
       memberId: character.member_id,
       isPublic: character.is_public,
       nickname: character.last_snapshot.snapshot.nickname,
+      image: character.last_snapshot.snapshot.image,
       createdAt: character.last_snapshot.snapshot.created_at.toISOString(),
       personality: character.characterPersonalites.map(
         (el) => el.personality.keyword,

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -77,7 +77,7 @@ export class CharactersService {
             },
           },
         },
-        characterPersonalites: {
+        character_personalites: {
           select: {
             personality: {
               select: { keyword: true },
@@ -107,7 +107,7 @@ export class CharactersService {
       image: snapshot.image,
       createdAt: snapshot.created_at.toISOString(),
 
-      personality: character.characterPersonalites.map(
+      personality: character.character_personalites.map(
         (el) => el.personality.keyword,
       ),
     };

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -43,18 +43,14 @@ export class CharactersService {
     });
 
     // 2. 캐릭터 ㅡ 성격 관계 지정
-    const characterPersonalities = input.personalities.map(
-      (personalityId): Prisma.Character_PersonalityCreateManyInput => ({
-        character_id: character.id,
-        personality_id: personalityId,
-        created_at: date,
-      }),
+    await this.createCharacterPersonalities(
+      characterId,
+      input.personalities,
+      date,
     );
 
-    // 3. 관계 데이터 삽입
-    await this.prisma.character_Personality.createMany({
-      data: characterPersonalities,
-    });
+    // 3. 캐릭터 ㅡ 경험 관계 지정
+    await this.createCharacterExperiences(characterId, input.experiences, date);
 
     return character;
   }
@@ -162,6 +158,42 @@ export class CharactersService {
       count,
       skip,
       take,
+    });
+  }
+
+  private async createCharacterPersonalities(
+    characterId: string,
+    personalities: Character.CreateRequest['personalities'],
+    date: string,
+  ) {
+    const characterPersonalities = personalities.map(
+      (personalityId): Prisma.Character_PersonalityCreateManyInput => ({
+        character_id: characterId,
+        personality_id: personalityId,
+        created_at: date,
+      }),
+    );
+
+    await this.prisma.character_Personality.createMany({
+      data: characterPersonalities,
+    });
+  }
+
+  private async createCharacterExperiences(
+    characterId: string,
+    experiences: Character.CreateRequest['experiences'],
+    date: string,
+  ) {
+    const characterExperiences = experiences.map(
+      (personalityId): Prisma.Character_ExperienceCreateManyInput => ({
+        character_id: characterId,
+        experience_id: personalityId,
+        created_at: date,
+      }),
+    );
+
+    await this.prisma.character_Experience.createMany({
+      data: characterExperiences,
     });
   }
 }

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -32,6 +32,20 @@ export class CharactersService {
             position: input.position,
             image: input.image,
             created_at: date,
+            character_snapshot_experiences: {
+              createMany: {
+                data: input.experiences.map(
+                  (
+                    experinceId,
+                  ): Prisma.Character_Snapshot_ExperienceCreateManyCharacter_snapshotInput => {
+                    return {
+                      experience_id: experinceId,
+                      created_at: date,
+                    };
+                  },
+                ),
+              },
+            },
           },
         },
         last_snapshot: {
@@ -48,9 +62,6 @@ export class CharactersService {
       input.personalities,
       date,
     );
-
-    // 3. 캐릭터 ㅡ 경험 관계 지정
-    await this.createCharacterExperiences(characterId, input.experiences, date);
 
     return character;
   }
@@ -103,7 +114,7 @@ export class CharactersService {
       image: snapshot.image,
       createdAt: snapshot.created_at.toISOString(),
 
-      personality: character.character_personalites.map(
+      personalities: character.character_personalites.map(
         (el) => el.personality.keyword,
       ),
     };
@@ -176,24 +187,6 @@ export class CharactersService {
 
     await this.prisma.character_Personality.createMany({
       data: characterPersonalities,
-    });
-  }
-
-  private async createCharacterExperiences(
-    characterId: string,
-    experiences: Character.CreateRequest['experiences'],
-    date: string,
-  ) {
-    const characterExperiences = experiences.map(
-      (personalityId): Prisma.Character_ExperienceCreateManyInput => ({
-        character_id: characterId,
-        experience_id: personalityId,
-        created_at: date,
-      }),
-    );
-
-    await this.prisma.character_Experience.createMany({
-      data: characterExperiences,
     });
   }
 }


### PR DESCRIPTION
## 캐릭터 생성 기능을 확장합니다.
캐릭터 생성시 저장하는 정보를 확대합니다. 상세 조회에도 동일하게 반영합니다.
- [x] 프로필 이미지(image 칼럼 추가)

성격은 캐릭터와 다대다 관계를 가집니다.
- [x] 성격(Personality 테이블 관계 추가)

경력은 캐릭터 스냅샷과 다대다 관계를 가집니다.
- [x] 경력 (Experience 테이블 관계 추가) 

###  📌 관련이슈

### ✏️ 작업내용

1. Character(캐릭터) 스키마 변경 
- 프로필 이미지를 저장하는 `image`칼럼추가
- 생성시 optinal 파라미터로 받는다. (비워둘 수 있음)
- 이미지가 저장되지 않은 경우 조회시 null로 응답한다.

2. Personality(성격) 테이블 및 관계 추가 https://github.com/Resupath/backend/pull/14
- 성격 테이블은 캐릭터 테이블과 다대다 관계를 가진다. 
- 사용자는 캐릭터 생성시 저장된 성격들 중 최소 하나를 선택해 지정해야 합니다.

3. Experience(경력) 테이블 관계 추가  https://github.com/Resupath/backend/pull/16
- 경력 테이블은 캐릭터 스냅샷 테이블과 다대다 관계를 가진다.
- 사용자는 저장된 경력을 불러와 캐릭터 생성시 사용할 수 있습니다.

4. 캐릭터 생성 API 보완
- `POST /characters`
- 확장된 구조에 따라 캐릭터 생성 API 수정.
- 내부 비즈니스 로직 수정 및 상세 조회 API 응답값에 노출되도록 반영.

5. 기타 
- 인터페이스 타입 추가 정의 및 재사용 하도록 리팩토링