### PR TITLE
[Feat] Add & Get Position 

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -102,7 +102,6 @@ erDiagram
   String id PK
   String character_id FK
   String nickname
-  String position
   String image "nullable"
   DateTime created_at
 }
@@ -117,6 +116,16 @@ erDiagram
   DateTime deleted_at "nullable"
 }
 "Personality" {
+  String id PK
+  String keyword
+  DateTime created_at
+  DateTime deleted_at "nullable"
+}
+"Character_Snapshot_Position" {
+  String character_snapshot_id FK
+  String position_id FK
+}
+"Position" {
   String id PK
   String keyword
   DateTime created_at
@@ -151,6 +160,8 @@ erDiagram
 "Character_Last_Snapshot" |o--|| "Character_Snapshot" : snapshot
 "Character_Personality" }o--|| "Personality" : personality
 "Character_Personality" }o--|| "Character" : character
+"Character_Snapshot_Position" }o--|| "Character_Snapshot" : character_snapshot
+"Character_Snapshot_Position" }o--|| "Position" : postion
 "Room" }o--|| "User" : user
 "Room" }o--|| "Character" : character
 "Chat" }o--o| "User" : user
@@ -216,7 +227,6 @@ erDiagram
   - `id`: PK
   - `character_id`: 스냅샷이 참조하는 캐릭터 ID
   - `nickname`: 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
-  - `position`: 캐릭터의 직군. 프론트엔드, 백엔드 등을 입력할 수 있다.
   - `image`: 캐릭터 프로필 이미지. s3 url을 저장한다.
   - `created_at`: 스냅샷 생성 시점
 
@@ -246,6 +256,24 @@ erDiagram
   - `keyword`: 성격에 대해 설명하는 단어나 문장. '용감한', '호기심이 많은' 같은 성격과 관련된 키워드이다.
   - `created_at`: 성격이 생성된 시점
   - `deleted_at`: 성격이 삭제된 시점
+
+### `Character_Snapshot_Position`
+캐릭터의 직군 정보
+사용자는 캐릭터 생성시 직군에 관한 정보를 입력할 수 있다.
+
+**Properties**
+  - `character_snapshot_id`: 
+  - `position_id`: 
+
+### `Position`
+직군.
+프론트, 백엔드 같은 직군의 정보를 저장한다.
+
+**Properties**
+  - `id`: PK
+  - `keyword`: 직군을 표현하는 단어를 뜻한다.
+  - `created_at`: 직군이 등록된 시점
+  - `deleted_at`: 직군이 삭제된 시점
 
 ### `Room`
 채팅방.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,13 +139,13 @@ model Character_Snapshot {
   id           String   @id @db.Uuid /// PK
   character_id String   @db.Uuid /// 스냅샷이 참조하는 캐릭터 ID
   nickname     String /// 캐릭터의 이름, 사용자 본명을 사용하는 것이 권장되나 강제성은 없다.
-  position     String /// 캐릭터의 직군. 프론트엔드, 백엔드 등을 입력할 수 있다.
   image        String? /// 캐릭터 프로필 이미지. s3 url을 저장한다.
   created_at   DateTime @db.Timestamptz /// 스냅샷 생성 시점
 
   character                      Character                       @relation(fields: [character_id], references: [id])
   last_snapshot                  Character_Last_Snapshot?
   character_snapshot_experiences Character_Snapshot_Experience[]
+  character_snapshot_positions   Character_Snapshot_Position[]
 }
 
 /// 캐릭터의 마지막 스냅샷
@@ -185,6 +185,31 @@ model Personality {
   deleted_at DateTime? @db.Timestamptz /// 성격이 삭제된 시점
 
   character_personalites Character_Personality[]
+}
+
+/// 캐릭터의 직군 정보
+/// 사용자는 캐릭터 생성시 직군에 관한 정보를 입력할 수 있다.
+/// @namespace Character
+model Character_Snapshot_Position {
+  character_snapshot_id String @db.Uuid //  Character_Snapshot FK
+  position_id           String @db.Uuid // Postion FK
+
+  character_snapshot Character_Snapshot @relation(fields: [character_snapshot_id], references: [id])
+  postion            Position           @relation(fields: [position_id], references: [id])
+
+  @@unique([character_snapshot_id, position_id])
+}
+
+/// 직군.
+/// 프론트, 백엔드 같은 직군의 정보를 저장한다.
+/// @namespace Character
+model Position {
+  id         String    @id @db.Uuid /// PK
+  keyword    String /// 직군을 표현하는 단어를 뜻한다.
+  created_at DateTime  @db.Timestamptz /// 직군이 등록된 시점
+  deleted_at DateTime? @db.Timestamptz /// 직군이 삭제된 시점
+
+  character_snapshot_positions Character_Snapshot_Position[]
 }
 
 /// 채팅방.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { PrismaModule } from './modules/prisma.module';
 import { CharactersModule } from './modules/characters.module';
 import { PersonalitiesModule } from './modules/personalities.module';
 import { ExperiencesModule } from './modules/experiences.module';
+import { PositionsModule } from './modules/positions.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ExperiencesModule } from './modules/experiences.module';
     CharactersModule,
     PersonalitiesModule,
     ExperiencesModule,
+    PositionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/controllers/positions.controller.ts
+++ b/src/controllers/positions.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { PositionsService } from 'src/services/positions.service';
+
+@Controller('positions')
+export class PositionsController {
+  constructor(private readonly positionsService: PositionsService) {}
+}

--- a/src/controllers/positions.controller.ts
+++ b/src/controllers/positions.controller.ts
@@ -1,7 +1,32 @@
-import { Controller } from '@nestjs/common';
+import core from '@nestia/core';
+import { Controller, UseGuards } from '@nestjs/common';
+import { MemberGuard } from 'src/guards/member.guard';
+import { Position } from 'src/interfaces/positions.interface';
 import { PositionsService } from 'src/services/positions.service';
 
 @Controller('positions')
 export class PositionsController {
   constructor(private readonly positionsService: PositionsService) {}
+
+  /**
+   * 직군을 생성한다.
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Post()
+  async createPosition(
+    @core.TypedBody() body: Position.CreateRequest,
+  ): Promise<Position.CreateResponse> {
+    return await this.positionsService.create(body);
+  }
+
+  /**
+   * 직군을 페이지네이션으로 조회한다.
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get()
+  async getPositionByPage(
+    @core.TypedQuery() query: Position.GetByPage,
+  ): Promise<Position.GetByPageResponse> {
+    return await this.positionsService.getByPage(query);
+  }
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -19,13 +19,8 @@ export namespace Character {
    * create
    */
   export interface CreateRequest
-<<<<<<< HEAD
-    extends Pick<Character, 'nickname' | 'isPublic' | 'position'>,
+    extends Pick<Character, 'nickname' | 'isPublic'>,
       Partial<Pick<Character, 'image'>> {
-=======
-    extends Pick<Character, 'nickname' | 'isPublic'> {
-    image?: Character['image'];
->>>>>>> b39d0f3 (feat: Position 스키마 정의 추가)
     personalities: Array<Personality['id']> & tags.MinItems<1>;
     experiences: Array<Experience['id']> & tags.MinItems<1>;
   }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -8,7 +8,6 @@ export interface Character {
   id: string & tags.Format<'uuid'>;
   memberId: Member['id'];
   nickname: string & tags.MinLength<1>;
-  position: string & tags.MinLength<1>;
   image: (string & tags.MinLength<1>) | null;
   isPublic: boolean;
   createdAt: string & tags.Format<'date-time'>;
@@ -20,8 +19,13 @@ export namespace Character {
    * create
    */
   export interface CreateRequest
+<<<<<<< HEAD
     extends Pick<Character, 'nickname' | 'isPublic' | 'position'>,
       Partial<Pick<Character, 'image'>> {
+=======
+    extends Pick<Character, 'nickname' | 'isPublic'> {
+    image?: Character['image'];
+>>>>>>> b39d0f3 (feat: Position 스키마 정의 추가)
     personalities: Array<Personality['id']> & tags.MinItems<1>;
     experiences: Array<Experience['id']> & tags.MinItems<1>;
   }
@@ -34,13 +38,7 @@ export namespace Character {
   export interface GetResponse
     extends Pick<
       Character,
-      | 'id'
-      | 'memberId'
-      | 'nickname'
-      | 'position'
-      | 'image'
-      | 'isPublic'
-      | 'createdAt'
+      'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'
     > {
     personalities: Array<Personality['keyword']>;
   }

--- a/src/interfaces/positions.interface.ts
+++ b/src/interfaces/positions.interface.ts
@@ -1,0 +1,27 @@
+import { PaginationUtil } from 'src/util/pagination.util';
+import { tags } from 'typia';
+
+export interface Position {
+  id: string & tags.Format<'uuid'>;
+  keyword: string & tags.MinLength<1>;
+}
+
+export namespace Position {
+  /**
+   * create
+   */
+  export interface CreateRequest extends Pick<Position, 'keyword'> {}
+  export interface CreateResponse extends Pick<Position, 'id'> {}
+
+  /**
+   * get
+   */
+  export interface GetByPage extends PaginationUtil.Request {
+    search?: string | null;
+  }
+
+  export interface GetResponse extends Pick<Position, 'id' | 'keyword'> {}
+
+  export interface GetByPageResponse
+    extends PaginationUtil.Response<Position.GetResponse> {}
+}

--- a/src/modules/positions.module.ts
+++ b/src/modules/positions.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PositionsService } from '../services/positions.service';
+import { PositionsController } from 'src/controllers/positions.controller';
+
+@Module({
+  controllers: [PositionsController],
+  providers: [PositionsService],
+})
+export class PositionsModule {}

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -29,7 +29,6 @@ export class CharactersService {
           create: {
             id: snapshotId,
             nickname: input.nickname,
-            position: input.position,
             image: input.image,
             created_at: date,
             character_snapshot_experiences: {
@@ -77,7 +76,6 @@ export class CharactersService {
             snapshot: {
               select: {
                 nickname: true,
-                position: true,
                 image: true,
                 created_at: true,
               },
@@ -110,7 +108,6 @@ export class CharactersService {
       isPublic: character.is_public,
 
       nickname: snapshot.nickname,
-      position: snapshot.position,
       image: snapshot.image,
       createdAt: snapshot.created_at.toISOString(),
 

--- a/src/services/positions.service.ts
+++ b/src/services/positions.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PositionsService {}

--- a/src/services/positions.service.ts
+++ b/src/services/positions.service.ts
@@ -1,4 +1,43 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { Position } from 'src/interfaces/positions.interface';
+import { DateTimeUtil } from 'src/util/dateTime.util';
+import { PaginationUtil } from 'src/util/pagination.util';
+import { PrismaService } from './prisma.service';
 
 @Injectable()
-export class PositionsService {}
+export class PositionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(body: Position.CreateRequest): Promise<Position.CreateResponse> {
+    const data = DateTimeUtil.now();
+
+    return await this.prisma.position.create({
+      select: { id: true },
+      data: { id: randomUUID(), keyword: body.keyword, created_at: data },
+    });
+  }
+
+  async getByPage(
+    query: Position.GetByPage,
+  ): Promise<Position.GetByPageResponse> {
+    const { skip, take } = PaginationUtil.getOffset(query);
+
+    const whereInput: Prisma.PositionWhereInput | undefined = query.search
+      ? { keyword: { contains: query.search } }
+      : undefined;
+
+    const [data, count] = await this.prisma.$transaction([
+      this.prisma.position.findMany({
+        select: { id: true, keyword: true },
+        where: whereInput,
+        skip,
+        take,
+      }),
+      this.prisma.position.count({ where: whereInput }),
+    ]);
+
+    return PaginationUtil.createResponse({ data, count, skip, take });
+  }
+}

--- a/test/unit/positions.controller.spec.ts
+++ b/test/unit/positions.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PositionsController } from 'src/controllers/positions.controller';
+import { PositionsService } from '../../src/services/positions.service';
+
+describe('PositionsController', () => {
+  let controller: PositionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PositionsController],
+      providers: [PositionsService],
+    }).compile();
+
+    controller = module.get<PositionsController>(PositionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  /**
+   * 사용자는 직군을 생성 및 조회할 수 있다.
+   *
+   * 사용자는 검색을 통해 이미 저장되어있는 직군을 확인할 수 있으며, 없는 경우 등록할 수 있다.
+   */
+});


### PR DESCRIPTION
## 직군 생성 / 조회 기능을 추가합니다.
직군 모델을 정의하고 API를 구현합니다. 

직군테이블은 캐릭터 스냅샷과 다대다 관계를 가집니다.
- [x] 직군 (Position 테이블 관계 추가)


### ✏️ 작업내용
1. Position(직군) 테이블 관계 추가 
- 직군 테이블은 캐릭터 스냅샷 테이블과 다대다 관계를 가진다.
- 사용자는 캐릭터에 희망하는 직군을 입력할 수 있다. (여러개를 동시에 등록 할수 있다. ex. 프론트, 백엔드)

2. Position 생성 API 구현
- `POST /positions/` 
- 직군의 키워드를 받아 생성합니다.

3. Position 조회 API 구현
- `Get /positions/` 
- 직군을 페이지네이션으로 조회합니다. `search` 쿼리 파라미터로 검색도 가능합니다.
