### PR TITLE
[Feat] Add & Get Skill

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -33,7 +33,7 @@ erDiagram
 
 ### `User`
 한 브라우저에서 입장하여 브라우저를 종료하기 전, 즉 세션을 유저라고 한다.
-이 유저가 언제 접속해서 언제 퇴장했는지를 파악하기 위해 유저마다 생성 시간과 이탈 시간을 둔다.
+이 유저가 언제 ��속해서 언제 퇴장했는지를 파악하기 위해 유저마다 생성 시간과 이탈 시간을 둔다.
 
 **Properties**
   - `id`: PK
@@ -47,7 +47,7 @@ erDiagram
 **Properties**
   - `id`: PK
   - `name`: 사용자 이름으로, 면접 서비스기 때문에 실명을 사용한다. 단, 강제성은 없다.
-  - `created_at`: 유저가 가입한 ��간으로, 이 시간을 멤버가 된 시간으로 인식한다.
+  - `created_at`: 유저가 가입한 시간으로, 이 시간을 멤버가 된 시간으로 인식한다.
   - `deleted_at`: 회원탈퇴한 경우
 
 ### `Provider`
@@ -131,6 +131,16 @@ erDiagram
   DateTime created_at
   DateTime deleted_at "nullable"
 }
+"Character_Snapshot_Skill" {
+  String character_snapshot_id FK
+  String skill_id FK
+}
+"Skill" {
+  String id PK
+  String keyword
+  DateTime created_at
+  DateTime deleted_at "nullable"
+}
 "Room" {
   String id PK
   String user_id FK
@@ -163,6 +173,8 @@ erDiagram
 "Character_Personality" }o--|| "Character" : character
 "Character_Snapshot_Position" }o--|| "Character_Snapshot" : character_snapshot
 "Character_Snapshot_Position" }o--|| "Position" : postion
+"Character_Snapshot_Skill" }o--|| "Character_Snapshot" : character_snapshot
+"Character_Snapshot_Skill" }o--|| "Skill" : skill
 "Room" }o--|| "User" : user
 "Room" }o--|| "Character" : character
 "Chat" }o--|| "Room" : room
@@ -255,7 +267,7 @@ erDiagram
 
 **Properties**
   - `id`: PK
-  - `keyword`: 성격에 대해 설명하는 단어나 문장. '용감한', '호기심이 많은' 같은 성격과 관련된 키워��이다.
+  - `keyword`: 성격에 대해 설명하는 단어나 문장. '용감한', '호기심이 많은' 같은 성격과 관련된 키워드이다.
   - `created_at`: 성격이 생성된 시점
   - `deleted_at`: 성격이 삭제된 시점
 
@@ -264,8 +276,8 @@ erDiagram
 사용자는 캐릭터 생성시 직군에 관한 정보를 입력할 수 있다.
 
 **Properties**
-  - `character_snapshot_id`: 
-  - `position_id`: 
+  - `character_snapshot_id`: Character_Snapshot FK
+  - `position_id`: Postion FK
 
 ### `Position`
 직군.
@@ -276,6 +288,24 @@ erDiagram
   - `keyword`: 직군을 표현하는 단어를 뜻한다.
   - `created_at`: 직군이 등록된 시점
   - `deleted_at`: 직군이 삭제된 시점
+
+### `Character_Snapshot_Skill`
+캐릭터의 기술 스택 정보
+사용자는 캐릭터 생성시 기술 스택(스킬)에 관한 정보를 입력할 수 있다.
+
+**Properties**
+  - `character_snapshot_id`: Character_Snapshot FK
+  - `skill_id`: Skill FK
+
+### `Skill`
+기술 스택
+React, NestJS 기술 스택(스킬)의 정보를 저장한다.
+
+**Properties**
+  - `id`: PK
+  - `keyword`: 스킬의 이름
+  - `created_at`: 스킬이 등록된 시점
+  - `deleted_at`: 스킬이 삭제된 시점
 
 ### `Room`
 채팅방.
@@ -303,7 +333,7 @@ erDiagram
 
 ### `User`
 한 브라우저에서 입장하여 브라우저를 종료하기 전, 즉 세션을 유저라고 한다.
-이 유저가 언제 접속해서 언제 퇴장했는지를 파악하기 위해 유저마다 생성 시간과 이탈 시간을 둔다.
+이 유저가 언제 ��속해서 언제 퇴장했는지를 파악하기 위해 유저마다 생성 시간과 이탈 시간을 둔다.
 
 **Properties**
   - `id`: PK

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Character_Snapshot {
   last_snapshot                  Character_Last_Snapshot?
   character_snapshot_experiences Character_Snapshot_Experience[]
   character_snapshot_positions   Character_Snapshot_Position[]
+  character_snapshot_skills      Character_Snapshot_Skill[]
 }
 
 /// 캐릭터의 마지막 스냅샷
@@ -191,8 +192,8 @@ model Personality {
 /// 사용자는 캐릭터 생성시 직군에 관한 정보를 입력할 수 있다.
 /// @namespace Character
 model Character_Snapshot_Position {
-  character_snapshot_id String @db.Uuid //  Character_Snapshot FK
-  position_id           String @db.Uuid // Postion FK
+  character_snapshot_id String @db.Uuid ///  Character_Snapshot FK
+  position_id           String @db.Uuid /// Postion FK
 
   character_snapshot Character_Snapshot @relation(fields: [character_snapshot_id], references: [id])
   postion            Position           @relation(fields: [position_id], references: [id])
@@ -210,6 +211,31 @@ model Position {
   deleted_at DateTime? @db.Timestamptz /// 직군이 삭제된 시점
 
   character_snapshot_positions Character_Snapshot_Position[]
+}
+
+/// 캐릭터의 기술 스택 정보
+/// 사용자는 캐릭터 생성시 기술 스택(스킬)에 관한 정보를 입력할 수 있다.
+/// @namespace Character
+model Character_Snapshot_Skill {
+  character_snapshot_id String @db.Uuid ///  Character_Snapshot FK
+  skill_id              String @db.Uuid /// Skill FK
+
+  character_snapshot Character_Snapshot @relation(fields: [character_snapshot_id], references: [id])
+  skill              Skill              @relation(fields: [skill_id], references: [id])
+
+  @@unique([character_snapshot_id, skill_id])
+}
+
+/// 기술 스택
+/// React, NestJS 기술 스택(스킬)의 정보를 저장한다.
+/// @namespace Character
+model Skill {
+  id         String    @id @db.Uuid /// PK
+  keyword    String /// 스킬의 이름
+  created_at DateTime  @db.Timestamptz /// 스킬이 등록된 시점
+  deleted_at DateTime? @db.Timestamptz /// 스킬이 삭제된 시점
+
+  character_snapshot_skills Character_Snapshot_Skill[]
 }
 
 /// 채팅방.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { PositionsModule } from './modules/positions.module';
 import { PrismaModule } from './modules/prisma.module';
 import { RoomsModule } from './modules/rooms.module';
 import { OpenaiModule } from './modules/openai.module';
+import { SkillsModule } from './modules/skills.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { OpenaiModule } from './modules/openai.module';
     PositionsModule,
     ChatsModule,
     RoomsModule,
+    SkillsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/controllers/skills.controller.ts
+++ b/src/controllers/skills.controller.ts
@@ -1,7 +1,32 @@
-import { Controller } from '@nestjs/common';
+import core from '@nestia/core';
+import { Controller, UseGuards } from '@nestjs/common';
+import { MemberGuard } from 'src/guards/member.guard';
+import { Skill } from 'src/interfaces/skills.interface';
 import { SkillsService } from 'src/services/skills.service';
 
 @Controller('skills')
 export class SkillsController {
   constructor(private readonly skillsService: SkillsService) {}
+
+  /**
+   * 스킬을 생성한다.
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Post()
+  async createSkill(
+    @core.TypedBody() body: Skill.CreateRequest,
+  ): Promise<Skill.CreateResponse> {
+    return await this.skillsService.create(body);
+  }
+
+  /**
+   * 스킬을 페이지네이션으로 조회한다.
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get()
+  async getPositionByPage(
+    @core.TypedQuery() query: Skill.GetByPage,
+  ): Promise<Skill.GetByPageResponse> {
+    return await this.skillsService.getByPage(query);
+  }
 }

--- a/src/controllers/skills.controller.ts
+++ b/src/controllers/skills.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { SkillsService } from 'src/services/skills.service';
+
+@Controller('skills')
+export class SkillsController {
+  constructor(private readonly skillsService: SkillsService) {}
+}

--- a/src/interfaces/skills.interface.ts
+++ b/src/interfaces/skills.interface.ts
@@ -1,0 +1,30 @@
+import { PaginationUtil } from 'src/util/pagination.util';
+import { tags } from 'typia';
+
+export interface Skill {
+  id: string & tags.Format<'uuid'>;
+  keyword: string & tags.MinLength<1>;
+  createdAt: string & tags.Format<'date-time'>;
+  deletedAt: string & tags.Format<'date-time'>;
+}
+
+export namespace Skill {
+  /**
+   * create
+   */
+  export interface CreateRequest extends Pick<Skill, 'keyword'> {}
+
+  export interface CreateResponse extends Pick<Skill, 'id'> {}
+
+  /**
+   * get
+   */
+  export interface GetByPage extends PaginationUtil.Request {
+    search?: string | null;
+  }
+
+  export interface GetResponse extends Pick<Skill, 'id' | 'keyword'> {}
+
+  export interface GetByPageResponse
+    extends PaginationUtil.Response<Skill.GetResponse> {}
+}

--- a/src/modules/skills.module.ts
+++ b/src/modules/skills.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SkillsService } from '../services/skills.service';
+import { SkillsController } from 'src/controllers/skills.controller';
+
+@Module({
+  controllers: [SkillsController],
+  providers: [SkillsService],
+})
+export class SkillsModule {}

--- a/src/services/skills.service.ts
+++ b/src/services/skills.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SkillsService {}

--- a/src/services/skills.service.ts
+++ b/src/services/skills.service.ts
@@ -1,4 +1,47 @@
 import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Skill } from 'src/interfaces/skills.interface';
+import { DateTimeUtil } from 'src/util/dateTime.util';
+import { PrismaService } from './prisma.service';
+import { PaginationUtil } from 'src/util/pagination.util';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
-export class SkillsService {}
+export class SkillsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(body: Skill.CreateRequest): Promise<Skill.CreateResponse> {
+    const date = DateTimeUtil.now();
+
+    return await this.prisma.skill.create({
+      select: { id: true },
+      data: { id: randomUUID(), keyword: body.keyword, created_at: date },
+    });
+  }
+
+  async getByPage(query: Skill.GetByPage): Promise<Skill.GetByPageResponse> {
+    const { skip, take } = PaginationUtil.getOffset(query);
+
+    const whereInput: Prisma.SkillWhereInput | undefined = query.search
+      ? { keyword: { contains: query.search } }
+      : undefined;
+
+    const [data, count] = await this.prisma.$transaction([
+      this.prisma.skill.findMany({
+        select: { id: true, keyword: true },
+        where: whereInput,
+        skip,
+        take,
+      }),
+
+      this.prisma.skill.count({ where: whereInput }),
+    ]);
+
+    return PaginationUtil.createResponse({
+      data,
+      count,
+      skip,
+      take,
+    });
+  }
+}

--- a/test/unit/skills.controller.spec.ts
+++ b/test/unit/skills.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SkillsController } from 'src/controllers/skills.controller';
+import { SkillsService } from 'src/services/skills.service';
+
+describe('SkillsController', () => {
+  let controller: SkillsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SkillsController],
+      providers: [SkillsService],
+    }).compile();
+
+    controller = module.get<SkillsController>(SkillsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 스킬 생성 / 조회 기능을 추가합니다.
스킬 모델을 정의하고 API를 구현합니다. 

스킬 테이블은 캐릭터 스냅샷과 다대다 관계를 가집니다.
- [x] 스킬 (Skill 테이블 관계 추가)


### ✏️ 작업내용
1. Skill(스킬) 테이블 관계 추가 
- Skill 테이블은 캐릭터 스냅샷 테이블과 다대다 관계를 가진다.
- 사용자는 캐릭터에 희망하는 스킬을 지정할 수 있다.

2. Skill 생성 API 구현
- `POST /skills/` 
- 스킬의 키워드를 받아 생성합니다.

3. Skill 조회 API 구현
- `Get /skills/` 
- 스킬을 페이지네이션으로 조회합니다. `search` 쿼리 파라미터로 검색도 지원합니다.
