### PR TITLE
[Feat] Add User 

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,7 +1,10 @@
 import core from '@nestia/core';
-import { Controller } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { User } from 'src/decorators/user.decorator';
+import { UserGuard } from 'src/guards/user.guard';
 import { Auth } from 'src/interfaces/auth.interface';
+import { Guard } from 'src/interfaces/guard.interface';
 import { AuthService } from 'src/services/auth.service';
 
 @ApiTags('Auth')
@@ -38,10 +41,12 @@ export class AuthController {
   /**
    * 클라이언트에서 받은 코드를 이용해 유저를 검증하고 jwt를 발급한다.
    */
+  @UseGuards(UserGuard)
   @core.TypedRoute.Get('google/callback')
   async getGoogleAuthorization(
+    @User() user: Guard.UserResponse,
     @core.TypedQuery() query: Auth.LoginRequest,
   ): Promise<Auth.LoginResponse> {
-    return this.authService.getGoogleAuthorization(query.code);
+    return this.authService.getGoogleAuthorization(user.id, query.code);
   }
 }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,8 +1,10 @@
 import core from '@nestia/core';
 import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { Auth } from 'src/interfaces/auth.interface';
 import { AuthService } from 'src/services/auth.service';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -8,6 +8,14 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   /**
+   * user를 생성하고 토큰을 발급한다.
+   */
+  @core.TypedRoute.Get('user')
+  async createUser(): Promise<Auth.UserToken> {
+    return await this.authService.getUserToken();
+  }
+
+  /**
    * AccessToken과 RefreshToken을 재발급 한다.
    */
   @core.TypedRoute.Post('refresh')

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -1,9 +1,10 @@
 import core from '@nestia/core';
 import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { User } from 'src/decorators/user.decorator';
+import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
 import { Character } from 'src/interfaces/characters.interface';
+import { Guard } from 'src/interfaces/guard.interface';
 import { CharactersService } from 'src/services/characters.service';
 import { tags } from 'typia';
 
@@ -18,10 +19,10 @@ export class CharactersController {
   @UseGuards(MemberGuard)
   @core.TypedRoute.Post()
   async createCharacater(
-    @User() user: { id: string },
+    @Member() member: Guard.MemberResponse,
     @core.TypedBody() body: Character.CreateRequest,
   ): Promise<Character.CreateResponse> {
-    return await this.charactersService.create(user.id, body);
+    return await this.charactersService.create(member.id, body);
   }
 
   /**

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -1,10 +1,13 @@
 import core, { TypedBody } from '@nestia/core';
 import { Controller, UseGuards } from '@nestjs/common';
-import { User } from 'src/decorators/user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
 import { Experience } from 'src/interfaces/experiences.interface';
+import { Guard } from 'src/interfaces/guard.interface';
 import { ExperiencesService } from '../services/experiences.service';
 
+@ApiTags('Experience')
 @Controller('experiences')
 export class ExperiencesController {
   constructor(private readonly experiencesService: ExperiencesService) {}
@@ -15,10 +18,10 @@ export class ExperiencesController {
   @UseGuards(MemberGuard)
   @core.TypedRoute.Post()
   async createExperiences(
-    @User() user: { id: string },
+    @Member() member: Guard.MemberResponse,
     @TypedBody() body: Experience.CreateRequest,
   ): Promise<void> {
-    return await this.experiencesService.create(user.id, body);
+    return await this.experiencesService.create(member.id, body);
   }
 
   /**
@@ -27,8 +30,8 @@ export class ExperiencesController {
   @UseGuards(MemberGuard)
   @core.TypedRoute.Get()
   async getAllExperiences(
-    @User() user: { id: string },
+    @Member() member: Guard.MemberResponse,
   ): Promise<Experience.GetAllResponse> {
-    return await this.experiencesService.getAll(user.id);
+    return await this.experiencesService.getAll(member.id);
   }
 }

--- a/src/decorators/member.decorator.ts
+++ b/src/decorators/member.decorator.ts
@@ -1,11 +1,11 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Guard } from 'src/interfaces/guard.interface';
 
-export const User = createParamDecorator(
+export const Member = createParamDecorator(
   (data: string | undefined, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
-    const user = request?.user;
+    const member = request?.member;
 
-    return user as Guard.UserResponse;
+    return member as Guard.MemberResponse;
   },
 );

--- a/src/guards/member.guard.ts
+++ b/src/guards/member.guard.ts
@@ -34,7 +34,7 @@ export class MemberGuard implements CanActivate {
         where: { id },
       });
 
-      request.user = member;
+      request.member = member;
 
       return member ? true : false;
     } catch (error) {

--- a/src/guards/member.guard.ts
+++ b/src/guards/member.guard.ts
@@ -44,7 +44,9 @@ export class MemberGuard implements CanActivate {
   }
 
   private getBearerToken(request: any): string | null {
-    const authHeader = request.headers['authorization'];
+    let authHeader = request.headers['X-Member'];
+    authHeader = authHeader ?? request.headers['authorization'];
+
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return null;
     }

--- a/src/guards/user.guard.ts
+++ b/src/guards/user.guard.ts
@@ -9,7 +9,7 @@ import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from 'src/services/prisma.service';
 
 @Injectable()
-export class MemberGuard implements CanActivate {
+export class UserGuard implements CanActivate {
   constructor(
     private readonly configService: ConfigService,
     private readonly jwtService: JwtService,
@@ -26,19 +26,19 @@ export class MemberGuard implements CanActivate {
       }
 
       const { id } = this.jwtService.verify(accessToken, {
-        secret: this.configService.get('JWT_SECRET_MEMBER'),
+        secret: this.configService.get('JWT_SECRET_USER'),
       });
 
-      const member = await this.prisma.member.findUnique({
+      const user = await this.prisma.user.findUnique({
         select: { id: true },
         where: { id },
       });
 
-      request.user = member;
+      request.user = user;
 
-      return member ? true : false;
+      return user ? true : false;
     } catch (error) {
-      console.error('Member Guard Error:', error);
+      console.error('User Guard Error:', error);
       throw new UnauthorizedException();
     }
   }

--- a/src/guards/user.guard.ts
+++ b/src/guards/user.guard.ts
@@ -44,7 +44,9 @@ export class UserGuard implements CanActivate {
   }
 
   private getBearerToken(request: any): string | null {
-    const authHeader = request.headers['authorization'];
+    let authHeader = request.headers['X-User'];
+    authHeader = authHeader ?? request.headers['authorization'];
+
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return null;
     }

--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -4,7 +4,7 @@ import { Provider } from './provider.interface';
 
 export namespace Auth {
   export interface UserToken {
-    userToken: string;
+    accessToken: string & tags.MinLength<1>;
   }
 
   export interface RefreshRequest {

--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -3,6 +3,10 @@ import { Member } from './member.interface';
 import { Provider } from './provider.interface';
 
 export namespace Auth {
+  export interface UserToken {
+    userToken: string;
+  }
+
   export interface RefreshRequest {
     refreshToken: string & tags.MinLength<1>;
   }

--- a/src/interfaces/guard.interface.ts
+++ b/src/interfaces/guard.interface.ts
@@ -1,0 +1,12 @@
+import { Member } from './member.interface';
+import { User } from './user.interface';
+
+export namespace Guard {
+  export interface UserResponse {
+    id: User['id'];
+  }
+
+  export interface MemberResponse {
+    id: Member['id'];
+  }
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -164,12 +164,12 @@ export class AuthService {
   }
 
   private createUserToken(user: Pick<User, 'id'>): Auth.UserToken {
-    const userToken = this.jwtService.sign(user, {
+    const accessToken = this.jwtService.sign(user, {
       secret: this.configService.get('JWT_SECRET_USER'),
       expiresIn: this.configService.get('JWT_EXPIRATION_TIME_USER'),
     });
 
-    return { userToken };
+    return { accessToken };
   }
 
   private async getGoogleAccessToken(code: string) {


### PR DESCRIPTION
## User 생성 기능 추가

### 📌 관련 이슈

### ✏️ 작업 내용
1. User 생성 및 토큰발급 API 추가
- `Get  /auth/user`
-  비회원용 accessToken을 발급합니다. 

2. User Guard, 데코레이터 생성
- 요청으로 헤더의 토큰을 읽어 User를 검증하는 User Guard를 추가하였습니다.

3. 회원가입 시 User 토큰을 입력받도록 수정
- 어떤 비회원이 회원으로 전환되었는지 추적하기 위함입니다.
- `auth/google/callback` API 요청시 user 토큰을 넘겨주어야 합니다.

4. 기타
- Guard 네임스페이스 정의. 가드 관련 응답 타입을 관리하기 위해 네임스페이스를 추가하였습니다.