### PR TITLE
[Extend] Get Character

### DIFF
--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -41,6 +41,7 @@ export namespace Character {
     > {
     personalities: Array<Personality['keyword']>;
     experienceYears: number & tags.Type<'int64'>;
+    roomCount: number & tags.Type<'int64'>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -40,13 +40,11 @@ export namespace Character {
       'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'
     > {
     personalities: Array<Personality['keyword']>;
+    experienceYears: number & tags.Type<'int64'>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}
 
-  export interface GetByPageData
-    extends Pick<Character, 'id' | 'nickname' | 'createdAt'> {}
-
   export interface GetByPageResponse
-    extends PaginationUtil.Response<GetByPageData> {}
+    extends PaginationUtil.Response<GetResponse> {}
 }

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -136,6 +136,7 @@ export class CharactersService {
             },
           },
         },
+        _count: { select: { rooms: true } },
       },
       where: { id, is_public: true },
     });
@@ -166,6 +167,7 @@ export class CharactersService {
         (el) => el.personality.keyword,
       ),
       experienceYears: experienceYears,
+      roomCount: character._count.rooms,
     };
   }
 
@@ -207,6 +209,9 @@ export class CharactersService {
               },
             },
           },
+          _count: {
+            select: { rooms: true },
+          },
         },
         where: whereInput,
         skip,
@@ -241,6 +246,7 @@ export class CharactersService {
           (el) => el.personality.keyword,
         ),
         experienceYears: experienceYears,
+        roomCount: el._count.rooms,
       };
     });
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -111,13 +111,13 @@ export class CharactersService {
         id: true,
         member_id: true,
         is_public: true,
+        created_at: true,
         last_snapshot: {
           select: {
             snapshot: {
               select: {
                 nickname: true,
                 image: true,
-                created_at: true,
                 character_snapshot_experiences: {
                   select: {
                     experience: {
@@ -157,10 +157,10 @@ export class CharactersService {
       id: character.id,
       memberId: character.member_id,
       isPublic: character.is_public,
+      createdAt: character.created_at.toISOString(),
 
       nickname: snapshot.nickname,
       image: snapshot.image,
-      createdAt: snapshot.created_at.toISOString(),
 
       personalities: character.character_personalites.map(
         (el) => el.personality.keyword,
@@ -182,13 +182,13 @@ export class CharactersService {
           id: true,
           member_id: true,
           is_public: true,
+          created_at: true,
           last_snapshot: {
             select: {
               snapshot: {
                 select: {
                   nickname: true,
                   image: true,
-                  created_at: true,
                   character_snapshot_experiences: {
                     select: {
                       experience: {
@@ -232,10 +232,10 @@ export class CharactersService {
         id: el.id,
         memberId: el.member_id,
         isPublic: el.is_public,
+        createdAt: el.created_at.toISOString(),
 
         nickname: snapshot.nickname,
         image: snapshot.image,
-        createdAt: snapshot.created_at.toISOString(),
 
         personalities: el.character_personalites.map(
           (el) => el.personality.keyword,

--- a/src/util/dateTime.util.ts
+++ b/src/util/dateTime.util.ts
@@ -3,7 +3,41 @@ export namespace DateTimeUtil {
    * 타임존을 포함한 시간을 반환한다.
    * @returns YYYY-MM-DDTHH:mm:ss.sssZ
    */
-  export function now() {
+  export const now = () => {
     return new Date().toISOString();
-  }
+  };
+
+  /**
+   * 날짜 간 개월수를 계산해 반환한다.
+   *
+   * @param startDate YYYY-MM-DD 형식의 문자열
+   * @param endDate YYYY-MM-DD 형식의 문자열
+   *
+   * @example BetweenMonths("2024-10-01", "2024-10-31"); // 같은 달 -> 1
+   * BetweenMonths("2024-10-01", "2024-12-01"); // 2
+   * BetweenMonths("2024-10-31", "2025-01-01"); // 3
+   * BetweenMonths("2022-05-15", "2024-06-20"); // 26
+   */
+  export const BetweenMonths = (
+    startDate: string,
+    endDate: string | null,
+  ): number => {
+    const start = new Date(startDate);
+    const end = endDate ? new Date(endDate) : new Date();
+
+    let months =
+      (end.getFullYear() - start.getFullYear()) * 12 +
+      (end.getMonth() - start.getMonth());
+
+    // 같은 달이면 1개월로 처리
+    if (months === 0) {
+      return 1;
+    }
+
+    if (end.getDate() >= start.getDate()) {
+      months += 1;
+    }
+
+    return months;
+  };
 }


### PR DESCRIPTION
## 캐릭터 조회 API의 응답필드를 확장합니다.

### ✏️ 작업 내용

1. 캐릭터  리스트 조회, 상세 조회 응답 필드 확장
```sh
- 별명 혹은 사용자가 지정한 이름
- 직군들
    - 여러 직군이 가능해야 합니다. 또는 여러 직군을 합쳐 부르는 말(ex. 풀스택)이 들어갈 수 있습니다.
- 경력(N년이라는 표기 혹은 아이콘용으로 필요할 수 있습니다.)
- 전체 채팅 수
- 캐릭터 최초 등록일자(스냅샷의 생성일자가 아닌, 최초의 캐릭터 등록일자를 의미)
```
- 별명, 직군 정보, 채팅방 수, 총 연차, 캐릭터 등록 일자, 이미지 응답 필드로 확장 


2. 기타
- 연차 계산 편의를 위한 BetweenMonths 유틸 함수 구현