### PR TITLE
[Feat] Add Chat

### DIFF
--- a/src/controllers/chats.controller.ts
+++ b/src/controllers/chats.controller.ts
@@ -1,7 +1,10 @@
 import core from '@nestia/core';
-import { Controller } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { User } from 'src/decorators/user.decorator';
+import { UserGuard } from 'src/guards/user.guard';
 import { Chat } from 'src/interfaces/chats.interface';
+import { Guard } from 'src/interfaces/guard.interface';
 import { Room } from 'src/interfaces/rooms.interface';
 import { ChatsService } from 'src/services/chats.service';
 
@@ -21,11 +24,13 @@ export class ChatsController {
   /**
    * 채팅방에 입력된 전체 채팅 기록을 바탕으로 캐릭터의 응답을 생성한다.
    */
+  @UseGuards(UserGuard)
   @core.TypedRoute.Post('/:roomId')
   async createChat(
+    @User() user: Guard.UserResponse,
     @core.TypedParam('roomId') roomId: Room['id'],
     @core.TypedBody() body: Chat.CreateRequst,
   ) {
-    return await this.chatsService.create(roomId, body);
+    return await this.chatsService.chat(user.id, roomId, body);
   }
 }

--- a/src/controllers/rooms.controller.ts
+++ b/src/controllers/rooms.controller.ts
@@ -17,10 +17,16 @@ export class RoomsController {
    */
   @UseGuards(UserGuard)
   @core.TypedRoute.Post()
-  async createRoom(
-    @User() user: Guard.UserResponse,
-    @core.TypedBody() body: Room.CreateRequest,
-  ) {
+  async createRoom(@User() user: Guard.UserResponse, @core.TypedBody() body: Room.CreateRequest) {
     return this.roomsService.create(user.id, body);
+  }
+
+  /**
+   * 채팅방을 조회한다.
+   */
+  @UseGuards(UserGuard)
+  @core.TypedRoute.Get(':id')
+  async getRoom(@User() user: Guard.UserResponse, @core.TypedParam('id') id: Room['id']) {
+    return this.roomsService.get(user.id, id);
   }
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -36,6 +36,8 @@ export namespace Character {
   export interface GetResponse
     extends Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'> {
     personalities: Array<Pick<Personality, 'id' | 'keyword'>>;
+    positions: Array<Pick<Position, 'id' | 'keyword'>>;
+    skills: Array<Pick<Skill, 'id' | 'keyword'>>;
     sources: Array<Pick<Source, 'id' | 'type' | 'url' | 'subtype' | 'createdAt'>>;
     experiences: Array<
       Pick<Experience, 'id' | 'companyName' | 'startDate' | 'endDate' | 'position' | 'description' | 'createdAt'>
@@ -56,6 +58,8 @@ export namespace Character {
       | 'isPublic'
       | 'createdAt'
       | 'personalities'
+      | 'positions'
+      | 'skills'
       | 'experienceYears'
       | 'roomCount'
     > {}

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -5,6 +5,7 @@ import { Member } from './member.interface';
 import { Personality } from './personalities.interface';
 import { Position } from './positions.interface';
 import { Skill } from './skills.interface';
+import { Source } from './source.interface';
 
 export interface Character {
   id: string & tags.Format<'uuid'>;
@@ -20,9 +21,7 @@ export namespace Character {
   /**
    * create
    */
-  export interface CreateRequest
-    extends Pick<Character, 'nickname' | 'isPublic'>,
-      Partial<Pick<Character, 'image'>> {
+  export interface CreateRequest extends Pick<Character, 'nickname' | 'isPublic'>, Partial<Pick<Character, 'image'>> {
     personalities: Array<Pick<Personality, 'id'>> & tags.MinItems<1>;
     experiences: Array<Pick<Experience, 'id'>> & tags.MinItems<1>;
     positions: Array<Position.CreateRequest> & tags.MinItems<1>;
@@ -35,17 +34,31 @@ export namespace Character {
    * get
    */
   export interface GetResponse
-    extends Pick<
-      Character,
-      'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'
-    > {
-    personalities: Array<Personality['keyword']>;
+    extends Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'> {
+    personalities: Array<Pick<Personality, 'id' | 'keyword'>>;
+    sources: Array<Pick<Source, 'id' | 'type' | 'url' | 'subtype' | 'createdAt'>>;
+    experiences: Array<
+      Pick<Experience, 'id' | 'companyName' | 'startDate' | 'endDate' | 'position' | 'description' | 'createdAt'>
+    >;
     experienceYears: number & tags.Type<'int64'>;
     roomCount: number & tags.Type<'int64'>;
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}
 
-  export interface GetByPageResponse
-    extends PaginationUtil.Response<GetResponse> {}
+  export interface GetBypageData
+    extends Pick<
+      GetResponse,
+      | 'id'
+      | 'memberId'
+      | 'nickname'
+      | 'image'
+      | 'isPublic'
+      | 'createdAt'
+      | 'personalities'
+      | 'experienceYears'
+      | 'roomCount'
+    > {}
+
+  export interface GetByPageResponse extends PaginationUtil.Response<Character.GetBypageData> {}
 }

--- a/src/interfaces/chats.interface.ts
+++ b/src/interfaces/chats.interface.ts
@@ -17,19 +17,14 @@ export namespace Chat {
   /**
    * create
    */
-  export interface CreateRequst
-    extends Pick<Chat, 'userId' | 'characterId' | 'message'> {}
+  export interface CreateRequst extends Pick<Chat, 'characterId' | 'message'> {}
 
   export interface CreateResponse extends Pick<Chat, 'id' | 'message'> {}
 
   /**
    * get
    */
-  export interface GetResponse
-    extends Pick<
-      Chat,
-      'id' | 'userId' | 'characterId' | 'message' | 'createdAt'
-    > {}
+  export interface GetResponse extends Pick<Chat, 'id' | 'userId' | 'characterId' | 'message' | 'createdAt'> {}
 
   export interface GetAllResponse extends Array<Chat.GetResponse> {}
 }

--- a/src/interfaces/rooms.interface.ts
+++ b/src/interfaces/rooms.interface.ts
@@ -17,4 +17,12 @@ export namespace Room {
   export interface CreateRequest extends Pick<Room, 'characterId'> {}
 
   export interface CreateResponse extends Pick<Room, 'id'> {}
+
+  /**
+   * get
+   */
+  export interface GetResponse extends Pick<Room, 'id' | 'createdAt'> {
+    user: Pick<User, 'id'>;
+    character: Pick<Character, 'id' | 'nickname' | 'createdAt'>;
+  }
 }

--- a/src/modules/characters.module.ts
+++ b/src/modules/characters.module.ts
@@ -8,5 +8,6 @@ import { SkillsModule } from './skills.module';
   imports: [PositionsModule, SkillsModule],
   controllers: [CharactersController],
   providers: [CharactersService],
+  exports: [CharactersService],
 })
 export class CharactersModule {}

--- a/src/modules/chats.module.ts
+++ b/src/modules/chats.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ChatsController } from 'src/controllers/chats.controller';
 import { ChatsService } from '../services/chats.service';
+import { CharactersModule } from './characters.module';
 import { OpenaiModule } from './openai.module';
+import { RoomsModule } from './rooms.module';
 
 @Module({
-  imports: [OpenaiModule],
+  imports: [OpenaiModule, RoomsModule, CharactersModule],
   controllers: [ChatsController],
   providers: [ChatsService],
 })

--- a/src/modules/rooms.module.ts
+++ b/src/modules/rooms.module.ts
@@ -5,5 +5,6 @@ import { RoomsService } from 'src/services/rooms.service';
 @Module({
   controllers: [RoomsController],
   providers: [RoomsService],
+  exports: [RoomsService],
 })
 export class RoomsModule {}

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -104,6 +104,20 @@ export class CharactersService {
               select: {
                 nickname: true,
                 image: true,
+                character_snapshot_positions: {
+                  select: {
+                    postion: {
+                      select: { id: true, keyword: true },
+                    },
+                  },
+                },
+                character_snapshot_skills: {
+                  select: {
+                    skill: {
+                      select: { id: true, keyword: true },
+                    },
+                  },
+                },
                 character_snapshot_experiences: {
                   select: {
                     experience: {
@@ -153,21 +167,6 @@ export class CharactersService {
       memberId: character.member_id,
       isPublic: character.is_public,
       createdAt: character.created_at.toISOString(),
-
-      nickname: snapshot.nickname,
-      image: snapshot.image,
-      experiences: snapshot.character_snapshot_experiences.map((el) => {
-        return {
-          id: el.experience.id,
-          companyName: el.experience.company_name,
-          position: el.experience.position,
-          description: el.experience.description,
-          startDate: el.experience.start_date,
-          endDate: el.experience.end_date,
-          createdAt: el.experience.created_at.toISOString(),
-        };
-      }),
-
       personalities: character.character_personalites.map((el) => {
         return { id: el.personality.id, keyword: el.personality.keyword };
       }),
@@ -180,6 +179,40 @@ export class CharactersService {
           createdAt: el.created_at.toISOString(),
         };
       }),
+
+      /**
+       * snapshot relation
+       */
+      nickname: snapshot.nickname,
+      image: snapshot.image,
+      positions: snapshot.character_snapshot_positions.map((el) => {
+        return {
+          id: el.postion.id,
+          keyword: el.postion.keyword,
+        };
+      }),
+      skills: snapshot.character_snapshot_skills.map((el) => {
+        return {
+          id: el.skill.id,
+          keyword: el.skill.keyword,
+        };
+      }),
+
+      experiences: snapshot.character_snapshot_experiences.map((el) => {
+        return {
+          id: el.experience.id,
+          companyName: el.experience.company_name,
+          position: el.experience.position,
+          description: el.experience.description,
+          startDate: el.experience.start_date,
+          endDate: el.experience.end_date,
+          createdAt: el.experience.created_at.toISOString(),
+        };
+      }),
+
+      /**
+       * aggregation
+       */
       experienceYears: experienceYears,
       roomCount: character._count.rooms,
     };
@@ -203,6 +236,23 @@ export class CharactersService {
                 select: {
                   nickname: true,
                   image: true,
+                  character_snapshot_positions: {
+                    select: {
+                      postion: {
+                        select: {
+                          id: true,
+                          keyword: true,
+                        },
+                      },
+                    },
+                  },
+                  character_snapshot_skills: {
+                    select: {
+                      skill: {
+                        select: { id: true, keyword: true },
+                      },
+                    },
+                  },
                   character_snapshot_experiences: {
                     select: {
                       experience: {
@@ -253,13 +303,31 @@ export class CharactersService {
         memberId: el.member_id,
         isPublic: el.is_public,
         createdAt: el.created_at.toISOString(),
-
-        nickname: snapshot.nickname,
-        image: snapshot.image,
-
         personalities: el.character_personalites.map((el) => {
           return { id: el.personality.id, keyword: el.personality.keyword };
         }),
+
+        /**
+         * snapshot relation
+         */
+        nickname: snapshot.nickname,
+        image: snapshot.image,
+        positions: snapshot.character_snapshot_positions.map((el) => {
+          return {
+            id: el.postion.id,
+            keyword: el.postion.keyword,
+          };
+        }),
+        skills: snapshot.character_snapshot_skills.map((el) => {
+          return {
+            id: el.skill.id,
+            keyword: el.skill.keyword,
+          };
+        }),
+
+        /**
+         * aggregation
+         */
         experienceYears: experienceYears,
         roomCount: el._count.rooms,
       };

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -107,7 +107,16 @@ export class CharactersService {
                 character_snapshot_experiences: {
                   select: {
                     experience: {
-                      select: { start_date: true, end_date: true },
+                      select: {
+                        id: true,
+                        company_name: true,
+                        position: true,
+                        description: true,
+                        start_date: true,
+                        end_date: true,
+                        created_at: true,
+                        sequence: true,
+                      },
                     },
                   },
                 },
@@ -115,10 +124,11 @@ export class CharactersService {
             },
           },
         },
+        sources: { select: { id: true, type: true, subtype: true, url: true, created_at: true } },
         character_personalites: {
           select: {
             personality: {
-              select: { keyword: true },
+              select: { id: true, keyword: true },
             },
           },
         },
@@ -146,8 +156,30 @@ export class CharactersService {
 
       nickname: snapshot.nickname,
       image: snapshot.image,
+      experiences: snapshot.character_snapshot_experiences.map((el) => {
+        return {
+          id: el.experience.id,
+          companyName: el.experience.company_name,
+          position: el.experience.position,
+          description: el.experience.description,
+          startDate: el.experience.start_date,
+          endDate: el.experience.end_date,
+          createdAt: el.experience.created_at.toISOString(),
+        };
+      }),
 
-      personalities: character.character_personalites.map((el) => el.personality.keyword),
+      personalities: character.character_personalites.map((el) => {
+        return { id: el.personality.id, keyword: el.personality.keyword };
+      }),
+      sources: character.sources.map((el) => {
+        return {
+          id: el.id,
+          type: el.type as 'link' | 'file',
+          subtype: el.subtype,
+          url: el.url,
+          createdAt: el.created_at.toISOString(),
+        };
+      }),
       experienceYears: experienceYears,
       roomCount: character._count.rooms,
     };
@@ -185,7 +217,7 @@ export class CharactersService {
           character_personalites: {
             select: {
               personality: {
-                select: { keyword: true },
+                select: { id: true, keyword: true },
               },
             },
           },
@@ -208,7 +240,7 @@ export class CharactersService {
     /**
      * mapping
      */
-    const data = characters.map((el): Character.GetResponse => {
+    const data = characters.map((el): Character.GetBypageData => {
       const snapshot = el?.last_snapshot?.snapshot;
 
       if (!snapshot) {
@@ -225,7 +257,9 @@ export class CharactersService {
         nickname: snapshot.nickname,
         image: snapshot.image,
 
-        personalities: el.character_personalites.map((el) => el.personality.keyword),
+        personalities: el.character_personalites.map((el) => {
+          return { id: el.personality.id, keyword: el.personality.keyword };
+        }),
         experienceYears: experienceYears,
         roomCount: el._count.rooms,
       };

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -3,14 +3,19 @@ import { randomUUID } from 'crypto';
 import { Chat } from 'src/interfaces/chats.interface';
 import { DateTimeUtil } from 'src/util/datetime.util';
 import { OpenaiUtil } from 'src/util/openai.util';
+import { PromptUtil } from 'src/util/prompt.util';
+import { CharactersService } from './characters.service';
 import { OpenaiService } from './openai.service';
 import { PrismaService } from './prisma.service';
+import { RoomsService } from './rooms.service';
 
 @Injectable()
 export class ChatsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly openaiService: OpenaiService,
+    private readonly roomsService: RoomsService,
+    private readonly charactersService: CharactersService,
   ) {}
 
   async getAll(roomId: string): Promise<Chat.GetAllResponse> {
@@ -39,21 +44,29 @@ export class ChatsService {
     });
   }
 
-  async create(id: string, body: Chat.CreateRequst) {
+  async chat(userId: string, roomId: string, body: Chat.CreateRequst) {
+    const room = await this.roomsService.get(userId, roomId);
+
     // 1. 질문 저장
-    await this.createUserChat(id, {
-      userId: body.userId,
+    await this.createUserChat(roomId, {
+      userId,
       message: body.message,
     });
 
     // 2. 채팅 기록 조회 및 매핑
-    const histories = await this.getChatHistories(id);
+    const chats = await this.getAll(roomId);
+
+    if (chats.length === 1) {
+      const prompt = await this.createSystemPrompt(room.character.id, roomId);
+      chats.push(prompt);
+    }
+    const histories = this.mappingHistories(chats);
 
     // 3. 응답 생성 (API 요청)
     const answer = await this.openaiService.getAnswer(histories);
 
     // 4. 응답 저장
-    await this.createCharacterChat(id, {
+    await this.createCharacterChat(roomId, {
       characterId: body.characterId,
       message: answer,
     });
@@ -61,54 +74,7 @@ export class ChatsService {
     return answer;
   }
 
-  /**
-   * Room에 저장된 이전 대화 목록을 조회한다. 조회 결과를 Openai request 형태로 매핑한다.
-   * 첫번째 질문이라면 system 프롬프트를 넣어준다.
-   */
-  private async getChatHistories(roomId: string): Promise<Array<OpenaiUtil.ChatCompletionRequestType>> {
-    const chats = await this.getAll(roomId);
-
-    if (chats.length === 1) {
-      const prompt = await this.createSystemPrompt(roomId);
-      chats.push(prompt);
-    }
-
-    /**
-     * mapping
-     */
-    let histories = chats.map((el): OpenaiUtil.ChatCompletionRequestType => {
-      const content = OpenaiUtil.createContents(el.message, el.createdAt);
-
-      if (el.userId !== null) {
-        return {
-          role: 'user',
-          content: content,
-        };
-      } else if (el.characterId !== null) {
-        return {
-          role: 'assistant',
-          content: content,
-        };
-      } else {
-        return {
-          role: 'system',
-          content: content,
-        };
-      }
-    });
-
-    return histories;
-  }
-
-  private async createSystemPrompt(roomId: string): Promise<Chat.GetResponse> {
-    const message = ['여기에 프롬프트', '내용을 작성합니다.'].join('\n');
-
-    const prompt = await this.createSystemChat(roomId, { message });
-
-    return prompt;
-  }
-
-  async createUserChat(roomId: string, body: Pick<Chat.CreateRequst, 'userId' | 'message'>): Promise<Chat.GetResponse> {
+  async createUserChat(roomId: string, body: Pick<Chat, 'userId' | 'message'>): Promise<Chat.GetResponse> {
     return this.createChat(roomId, {
       userId: body.userId,
       characterId: null,
@@ -116,10 +82,7 @@ export class ChatsService {
     });
   }
 
-  async createCharacterChat(
-    roomId: string,
-    body: Pick<Chat.CreateRequst, 'characterId' | 'message'>,
-  ): Promise<Chat.GetResponse> {
+  async createCharacterChat(roomId: string, body: Pick<Chat, 'characterId' | 'message'>): Promise<Chat.GetResponse> {
     return this.createChat(roomId, {
       userId: null,
       characterId: body.characterId,
@@ -127,7 +90,7 @@ export class ChatsService {
     });
   }
 
-  async createSystemChat(roomId: string, body: Pick<Chat.CreateRequst, 'message'>): Promise<Chat.GetResponse> {
+  async createSystemChat(roomId: string, body: Pick<Chat, 'message'>): Promise<Chat.GetResponse> {
     return this.createChat(roomId, {
       userId: null,
       characterId: null,
@@ -135,7 +98,18 @@ export class ChatsService {
     });
   }
 
-  private async createChat(roomId: string, body: Chat.CreateRequst): Promise<Chat.GetResponse> {
+  private async createSystemPrompt(characterId: string, roomId: string): Promise<Chat.GetResponse> {
+    const character = await this.charactersService.get(characterId);
+    const prompt = PromptUtil.prompt(character);
+
+    const chat = await this.createSystemChat(roomId, { message: prompt });
+    return chat;
+  }
+
+  private async createChat(
+    roomId: string,
+    body: Pick<Chat, 'userId' | 'characterId' | 'message'>,
+  ): Promise<Chat.GetResponse> {
     const date = DateTimeUtil.now();
 
     const chat = await this.prisma.chat.create({
@@ -166,5 +140,30 @@ export class ChatsService {
       message: chat.message,
       createdAt: chat.created_at.toISOString(),
     };
+  }
+
+  private mappingHistories(chats: Chat.GetAllResponse): Array<OpenaiUtil.ChatCompletionRequestType> {
+    const histories = chats.map((el): OpenaiUtil.ChatCompletionRequestType => {
+      const content = OpenaiUtil.createContents(el.message, el.createdAt);
+
+      if (el.userId !== null) {
+        return {
+          role: 'user',
+          content: content,
+        };
+      } else if (el.characterId !== null) {
+        return {
+          role: 'assistant',
+          content: content,
+        };
+      } else {
+        return {
+          role: 'system',
+          content: content,
+        };
+      }
+    });
+
+    return histories;
   }
 }

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -28,6 +28,7 @@ export class ChatsService {
         created_at: true,
       },
       where: { room_id: roomId },
+      orderBy: { created_at: 'asc' },
     });
 
     /**

--- a/src/util/prompt.util.ts
+++ b/src/util/prompt.util.ts
@@ -1,0 +1,67 @@
+import { Character } from 'src/interfaces/characters.interface';
+
+export namespace PromptUtil {
+  export const prompt = (input: Character.GetResponse): string => {
+    return [
+      addPolicy(),
+      ``,
+      `<기본 정보>`,
+      `- 이름: ${input.nickname}`,
+      `- 직무: ${addPositions(input)}`,
+      `- 사용 기술: ${addSkills(input)}`,
+      `- 경력: ${input.experienceYears}`,
+      `</기본 정보>`,
+      ``,
+      `<회사 경력>`,
+      addExperieces(input),
+      `</회사 경력>`,
+      ``,
+      `<첨부 자료>`,
+      addSources(input),
+      `</첨부 자료>`,
+      ``,
+      addIntro(),
+    ].join(`\n`);
+  };
+
+  export const addPolicy = (): string => {
+    return (
+      `너는 면접 대상자이다. 유저는 면접관이며, 너는 면접 대상자로서 역할을 충실히 수행해야 한다.\n` +
+      `주된 질문은 기술적 지식, 문제 해결 경험, 협업 사례, 적응력 인성과 관련이 있다. 너는 항상 논리적이고 자신감 있는 답변을 해야하며, AI 또는 에이전트라는 사실이 드러나서는 안 된다.\n` +
+      `유저가 면접과 관련 없는 질문을 할 경우 부드럽게 면접 관련 화제로 돌려야 한다.\n`
+    );
+  };
+
+  export const addPositions = (input: Character.GetResponse): string => {
+    return input.positions.map((el) => el.keyword).join(`, `);
+  };
+
+  export const addSkills = (input: Character.GetResponse): string => {
+    return input.skills.map((el) => el.keyword).join(`, `);
+  };
+
+  export const addExperieces = (input: Character.GetResponse): string[] => {
+    const experieces = input.experiences.map((el) => {
+      return [
+        `- 회사명: ${el.companyName}`,
+        `- 근무 기간: ${el.startDate} ~ ${el.endDate ?? '현재'}`,
+        `- 직무: ${el.position}`,
+        `- 주요 업무 및 성과: ${el.description}`,
+        ``,
+      ].join(`\n`);
+    });
+    return experieces;
+  };
+
+  export const addSources = (input: Character.GetResponse): string[] => {
+    const sources = input.sources.map((el) => {
+      return [`- ${el.subtype}`, `${el.type === 'file' ? el.url : el.url}`].join(`\n`);
+    });
+
+    return sources;
+  };
+
+  export const addIntro = (): string => {
+    return `이제 면접관(유저)이 질문을 시작할 것이다. 모든 답변은 자신감 있고 친절하며 구체적인 예시를 포함하도록 한다.`;
+  };
+}


### PR DESCRIPTION
## 채팅 기능을 구현합니다.

### 📌 관련 이슈

### ✏️ 변경 사항

1. 캐릭터 상세 조회 API 응답필드 확장
- 캐릭터 조회시 경력, 소스, 직군, 스킬에 대한 정보를 함께노출 하도록 수정합니다.

2. 채팅 API 구현
- `Get chats/:roomId`
- 채팅 프로세스는 다음과 같습니다
```ts
1. 질문 저장
2. 채팅 기록 조회 및 매핑
3. 응답 생성 (API 요청)
4. 응답 저장
```
- 첫 채팅시 캐릭터에 대한 정보를 학습할 수 있도록 시스템 프롬프트를 입력합니다. 
- 이후 채팅에서는 히스토리로 전체 채팅 내용을 학습소스로 사용합니다.

5. Room 조회 API 구현
- `Get rooms/:id`
- 아이디로 채팅방을 조회할 수 있는 API 를 추가하였습니다.