### PR TITLE
[Feat] get member

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { RoomsModule } from './modules/rooms.module';
 import { SkillsModule } from './modules/skills.module';
 import { SourcesModule } from './modules/sources.module';
 import { FileModule } from './modules/files.module';
+import { MembersModule } from './modules/members.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { FileModule } from './modules/files.module';
     SkillsModule,
     SourcesModule,
     FileModule,
+    MembersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -30,7 +30,7 @@ export class CharactersController {
    */
   @core.TypedRoute.Get()
   async getCharactersByPage(@core.TypedQuery() query: Character.GetByPageRequest) {
-    return await this.charactersService.getBypage(query);
+    return await this.charactersService.getBypage(query, { isPublic: true });
   }
 
   /**

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -29,7 +29,7 @@ export class MembersController {
    * 회원의 캐릭터 정보들를 페이지 네이션으로 조회한다.
    */
   @core.TypedRoute.Get('characters')
-  async getCharacters(@Member() member: Guard.MemberResponse) {
-    return 1;
+  async getCharacters(@Member() member: Guard.MemberResponse, @core.TypedQuery() query: Character.GetByPageRequest) {
+    return await this.charactersService.getBypage(query, member.id);
   }
 }

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -30,6 +30,6 @@ export class MembersController {
    */
   @core.TypedRoute.Get('characters')
   async getCharacters(@Member() member: Guard.MemberResponse, @core.TypedQuery() query: Character.GetByPageRequest) {
-    return await this.charactersService.getBypage(query, member.id);
+    return await this.charactersService.getBypage(query, { memberId: member.id });
   }
 }

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -22,7 +22,7 @@ export class MembersController {
    */
   @core.TypedRoute.Get('info')
   async getMember(@Member() member: Guard.MemberResponse) {
-    return 1;
+    return await this.membersService.get(member.id);
   }
 
   /**

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -1,0 +1,35 @@
+import core, { TypedQuery } from '@nestia/core';
+import { Controller, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Member } from 'src/decorators/member.decorator';
+import { MemberGuard } from 'src/guards/member.guard';
+import { Character } from 'src/interfaces/characters.interface';
+import { Guard } from 'src/interfaces/guard.interface';
+import { CharactersService } from 'src/services/characters.service';
+import { MembersService } from 'src/services/members.service';
+
+@ApiTags('Member')
+@UseGuards(MemberGuard)
+@Controller('members')
+export class MembersController {
+  constructor(
+    private readonly membersService: MembersService,
+    private readonly charactersService: CharactersService,
+  ) {}
+
+  /**
+   * 회원 정보를 조회한다.
+   */
+  @core.TypedRoute.Get('info')
+  async getMember(@Member() member: Guard.MemberResponse) {
+    return 1;
+  }
+
+  /**
+   * 회원의 캐릭터 정보들를 페이지 네이션으로 조회한다.
+   */
+  @core.TypedRoute.Get('characters')
+  async getCharacters(@Member() member: Guard.MemberResponse) {
+    return 1;
+  }
+}

--- a/src/interfaces/member.interface.ts
+++ b/src/interfaces/member.interface.ts
@@ -1,8 +1,18 @@
 import { tags } from 'typia';
+import { Provider } from './provider.interface';
 
 export interface Member {
   id: string & tags.Format<'uuid'>;
   name: string & tags.MinLength<1>;
   createdAt: string & tags.Format<'date-time'>;
   deletedAt: string & tags.Format<'date-time'>;
+}
+
+export namespace Member {
+  /**
+   * get
+   */
+  export interface GetResponse extends Pick<Member, 'id' | 'name' | 'createdAt'> {
+    providers: Array<Pick<Provider, 'id' | 'type' | 'createdAt'>>;
+  }
 }

--- a/src/interfaces/provider.interface.ts
+++ b/src/interfaces/provider.interface.ts
@@ -7,5 +7,5 @@ export interface Provider {
   type: ('google' | 'github' | 'linkedin') & tags.MinLength<1>;
   uid: string & tags.MinLength<1>;
   password: string & tags.MinLength<1>;
-  created_at: string & tags.Format<'date-time'>;
+  createdAt: string & tags.Format<'date-time'>;
 }

--- a/src/modules/members.module.ts
+++ b/src/modules/members.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MembersController } from 'src/controllers/members.controller';
+import { MembersService } from '../services/members.service';
+
+@Module({
+  imports: [],
+  controllers: [MembersController],
+  providers: [MembersService],
+})
+export class MembersModule {}

--- a/src/modules/members.module.ts
+++ b/src/modules/members.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { MembersController } from 'src/controllers/members.controller';
 import { MembersService } from '../services/members.service';
+import { CharactersModule } from './characters.module';
 
 @Module({
-  imports: [],
+  imports: [CharactersModule],
   controllers: [MembersController],
   providers: [MembersService],
 })

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Member, Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Character } from 'src/interfaces/characters.interface';
 import { Experience } from 'src/interfaces/experiences.interface';
@@ -227,10 +227,9 @@ export class CharactersService {
     };
   }
 
-  async getBypage(query: Character.GetByPageRequest): Promise<Character.GetByPageResponse> {
+  async getBypage(query: Character.GetByPageRequest, memberId?: Member['id']): Promise<Character.GetByPageResponse> {
     const { skip, take } = PaginationUtil.getOffset(query);
-
-    const whereInput: Prisma.CharacterWhereInput = { is_public: true };
+    const whereInput: Prisma.CharacterWhereInput = { is_public: true, member_id: memberId };
 
     const [characters, count] = await this.prisma.$transaction([
       this.prisma.character.findMany({

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -227,9 +227,15 @@ export class CharactersService {
     };
   }
 
-  async getBypage(query: Character.GetByPageRequest, memberId?: Member['id']): Promise<Character.GetByPageResponse> {
+  async getBypage(
+    query: Character.GetByPageRequest,
+    option: {
+      isPublic?: boolean;
+      memberId?: Member['id'];
+    },
+  ): Promise<Character.GetByPageResponse> {
     const { skip, take } = PaginationUtil.getOffset(query);
-    const whereInput: Prisma.CharacterWhereInput = { is_public: true, member_id: memberId };
+    const whereInput: Prisma.CharacterWhereInput = { is_public: option.isPublic, member_id: option.memberId };
 
     const [characters, count] = await this.prisma.$transaction([
       this.prisma.character.findMany({
@@ -348,6 +354,8 @@ export class CharactersService {
       take,
     });
   }
+
+  private async getFindManyInput() {}
 
   private async createCharacterPersonalities(
     characterId: string,

--- a/src/services/members.service.ts
+++ b/src/services/members.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MembersService {}

--- a/src/services/members.service.ts
+++ b/src/services/members.service.ts
@@ -1,4 +1,47 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+import { Member } from 'src/interfaces/member.interface';
+import { Provider } from 'src/interfaces/provider.interface';
 
 @Injectable()
-export class MembersService {}
+export class MembersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async get(id: Member['id']): Promise<Member.GetResponse> {
+    const member = await this.prisma.member.findUnique({
+      select: {
+        id: true,
+        name: true,
+        created_at: true,
+        providers: {
+          select: {
+            id: true,
+            type: true,
+            created_at: true,
+          },
+        },
+      },
+      where: { id },
+    });
+
+    if (!member) {
+      throw new NotFoundException();
+    }
+
+    /**
+     * mapping
+     */
+    return {
+      id: member.id,
+      name: member.name,
+      createdAt: member.created_at.toISOString(),
+      providers: member.providers.map((el) => {
+        return {
+          id: el.id,
+          type: el.type as Provider['type'],
+          createdAt: el.created_at.toISOString(),
+        };
+      }),
+    };
+  }
+}


### PR DESCRIPTION
## Member 관련한 기능을 추가합니다.
- 흔히 마이페이지라고 인식되는 회원 정보 관리 페이지에서 사용할 수 있는 기능들을 구현하였습니다.

### 📌 관련 이슈

### ✏️ 변경 사항

1. Member 정보 조회 API 추가
- `Get members/info`
- 저장된 member에 대한 정보와 연동된 Provider 정보를 응답합니다.

2. Member 캐릭터 조회 API 추가
- `Get members/characters`
- member가 생성한 캐릭터 정보를 조회합니다.
- 비공개 처리(`isPublic : true`)한 캐릭터도 조회 가능합니다.