### PR TITLE
[Feat] Update & Delete Experience

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -68,6 +68,12 @@ erDiagram
 "Experience" {
   String id PK
   String member_id FK
+  DateTime created_at
+  DateTime deleted_at "nullable"
+}
+"Experience_Snapshot" {
+  String id PK
+  String experience_id FK
   String company_name
   String position
   String start_date
@@ -75,7 +81,10 @@ erDiagram
   String description "nullable"
   Int sequence
   DateTime created_at
-  DateTime deleted_at "nullable"
+}
+"Experience_Last_Snapshot" {
+  String experience_id PK
+  String experience_snapshot_id FK
 }
 "Character_Snapshot_Experience" {
   String character_snapshot_id FK
@@ -164,6 +173,9 @@ erDiagram
   DateTime deleted_at "nullable"
   String member_id FK "nullable"
 }
+"Experience_Snapshot" }o--|| "Experience" : experience
+"Experience_Last_Snapshot" |o--|| "Experience" : experience
+"Experience_Last_Snapshot" |o--|| "Experience_Snapshot" : snapshot
 "Character_Snapshot_Experience" }o--|| "Character_Snapshot" : character_snapshot
 "Character_Snapshot_Experience" }o--|| "Experience" : experience
 "Source" }o--|| "Character" : character
@@ -189,14 +201,29 @@ erDiagram
 **Properties**
   - `id`: PK
   - `member_id`: 가입된 사용자가 경력을 입력할 수 있다.
+  - `created_at`: 경력을 최초 입력후 저장한 시간.
+  - `deleted_at`: 경력을 삭제한 경우.
+
+### `Experience_Snapshot`
+Experience의 스냅샷
+
+**Properties**
+  - `id`: PK
+  - `experience_id`: 
   - `company_name`: 
   - `position`: 직군을 입력한다. 
   - `start_date`: 근무 시작 날짜. 월까지 입력한다.
   - `end_date`: 근무 종료 날짜. 월까지 입력하며, 현재 재직 중일 경우 null이다.
   - `description`: 경력에 대한 설명. 업문 내용 등 사용자가 입력하고 싶은 것들을 적으며, 비워둘 수 있다.
   - `sequence`: 경력의 순서를 저장하는 필드이다. 유저에게 보여줄때 순서를 보장하기 위해 사용한다.
-  - `created_at`: 경력을 최초 입력후 저장한 시간.
-  - `deleted_at`: 경력을 삭제한 경우.
+  - `created_at`: 스냅샷 생성 시간.
+
+### `Experience_Last_Snapshot`
+Experience의 마지막 스냅샷
+
+**Properties**
+  - `experience_id`: 
+  - `experience_snapshot_id`: 
 
 ### `Character_Snapshot_Experience`
 캐릭터의 학습에 사용된 경력 사항들을 저장한다. 캐릭터 스냅샷과 다대다 관계를 가진다.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,19 +51,46 @@ model Member {
 /// `Member`의 경력사항을 나타낸다.
 /// @namespace Character
 model Experience {
-  id           String    @id @db.Uuid /// PK
-  member_id    String    @db.Uuid /// 가입된 사용자가 경력을 입력할 수 있다.
-  company_name String
-  position     String /// 직군을 입력한다. 
-  start_date   String /// 근무 시작 날짜. 월까지 입력한다.
-  end_date     String? /// 근무 종료 날짜. 월까지 입력하며, 현재 재직 중일 경우 null이다.
-  description  String? /// 경력에 대한 설명. 업문 내용 등 사용자가 입력하고 싶은 것들을 적으며, 비워둘 수 있다.
-  sequence     Int /// 경력의 순서를 저장하는 필드이다. 유저에게 보여줄때 순서를 보장하기 위해 사용한다.
-  created_at   DateTime  @db.Timestamptz /// 경력을 최초 입력후 저장한 시간.
-  deleted_at   DateTime? @db.Timestamptz /// 경력을 삭제한 경우.
+  id         String    @id @db.Uuid /// PK
+  member_id  String    @db.Uuid /// 가입된 사용자가 경력을 입력할 수 있다.
+  created_at DateTime  @db.Timestamptz /// 경력을 최초 입력후 저장한 시간.
+  deleted_at DateTime? @db.Timestamptz /// 경력을 삭제한 경우.
 
   memer                          Member                          @relation(fields: [member_id], references: [id])
   character_snapshot_experiences Character_Snapshot_Experience[]
+
+  /// 스냅샷들
+  snapshots     Experience_Snapshot[]
+  last_snapshot Experience_Last_Snapshot?
+}
+
+/// Experience의 스냅샷
+/// @namespace Character
+model Experience_Snapshot {
+  id            String   @id @db.Uuid /// PK
+  experience_id String   @db.Uuid
+  company_name  String
+  position      String /// 직군을 입력한다. 
+  start_date    String /// 근무 시작 날짜. 월까지 입력한다.
+  end_date      String? /// 근무 종료 날짜. 월까지 입력하며, 현재 재직 중일 경우 null이다.
+  description   String? /// 경력에 대한 설명. 업문 내용 등 사용자가 입력하고 싶은 것들을 적으며, 비워둘 수 있다.
+  sequence      Int /// 경력의 순서를 저장하는 필드이다. 유저에게 보여줄때 순서를 보장하기 위해 사용한다.
+  created_at    DateTime @db.Timestamptz /// 스냅샷 생성 시간.
+
+  experience    Experience                @relation(fields: [experience_id], references: [id])
+  last_snapshot Experience_Last_Snapshot?
+}
+
+/// Experience의 마지막 스냅샷
+/// @namespace Character
+model Experience_Last_Snapshot {
+  experience_id          String @id @db.Uuid
+  experience_snapshot_id String @db.Uuid
+
+  experience Experience          @relation(fields: [experience_id], references: [id])
+  snapshot   Experience_Snapshot @relation(fields: [experience_snapshot_id], references: [id])
+
+  @@unique([experience_snapshot_id])
 }
 
 /// 캐릭터의 학습에 사용된 경력 사항들을 저장한다. 캐릭터 스냅샷과 다대다 관계를 가진다.
@@ -143,8 +170,9 @@ model Character_Snapshot {
   image        String? /// 캐릭터 프로필 이미지. s3 url을 저장한다.
   created_at   DateTime @db.Timestamptz /// 스냅샷 생성 시점
 
-  character                      Character                       @relation(fields: [character_id], references: [id])
-  last_snapshot                  Character_Last_Snapshot?
+  character     Character                @relation(fields: [character_id], references: [id])
+  last_snapshot Character_Last_Snapshot?
+
   character_snapshot_experiences Character_Snapshot_Experience[]
   character_snapshot_positions   Character_Snapshot_Position[]
   character_snapshot_skills      Character_Snapshot_Skill[]
@@ -251,7 +279,7 @@ model Room {
 
   user      User      @relation(fields: [user_id], references: [id])
   character Character @relation(fields: [character_id], references: [id])
-  Chat      Chat[]
+  chats     Chat[]
 }
 
 /// 채팅 내용.

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -38,6 +38,20 @@ export class ExperiencesController {
   }
 
   /**
+   * 경력을 조회한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get('/:id')
+  async getExperience(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('id') id: Experience['id'],
+  ): Promise<Experience.GetResponse> {
+    return await this.experiencesService.get(member.id, id);
+  }
+
+  /**
    * 경력을 수정한다.
    *
    * @security x-member bearer

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -65,4 +65,18 @@ export class ExperiencesController {
   ): Promise<Experience.UpdateResponse> {
     return await this.experiencesService.update(member.id, id, body);
   }
+
+  /**
+   * 경력을 삭제한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Delete('/:id')
+  async deleteExperience(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('id') id: Experience['id'],
+  ): Promise<Experience.UpdateResponse> {
+    return await this.experiencesService.delete(member.id, id);
+  }
 }

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -22,7 +22,7 @@ export class ExperiencesController {
   async createExperiences(
     @Member() member: Guard.MemberResponse,
     @TypedBody() body: Experience.CreateRequest,
-  ): Promise<void> {
+  ): Promise<Array<Experience.GetResponse>> {
     return await this.experiencesService.createMany(member.id, body);
   }
 
@@ -33,7 +33,7 @@ export class ExperiencesController {
    */
   @UseGuards(MemberGuard)
   @core.TypedRoute.Get()
-  async getAllExperiences(@Member() member: Guard.MemberResponse): Promise<Experience.GetAllResponse> {
+  async getAllExperiences(@Member() member: Guard.MemberResponse): Promise<Array<Experience.GetResponse>> {
     return await this.experiencesService.getAll(member.id);
   }
 }

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -1,4 +1,4 @@
-import core, { TypedBody } from '@nestia/core';
+import core from '@nestia/core';
 import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
@@ -21,7 +21,7 @@ export class ExperiencesController {
   @core.TypedRoute.Post()
   async createExperiences(
     @Member() member: Guard.MemberResponse,
-    @TypedBody() body: Experience.CreateRequest,
+    @core.TypedBody() body: Experience.CreateManyRequest,
   ): Promise<Array<Experience.GetResponse>> {
     return await this.experiencesService.createMany(member.id, body);
   }
@@ -35,5 +35,20 @@ export class ExperiencesController {
   @core.TypedRoute.Get()
   async getAllExperiences(@Member() member: Guard.MemberResponse): Promise<Array<Experience.GetResponse>> {
     return await this.experiencesService.getAll(member.id);
+  }
+
+  /**
+   * 경력을 수정한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Patch('/:id')
+  async updateExperience(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('id') id: Experience['id'],
+    @core.TypedBody() body: Experience.UpdateRequest,
+  ): Promise<Experience.UpdateResponse> {
+    return await this.experiencesService.update(member.id, id, body);
   }
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -40,9 +40,7 @@ export namespace Character {
     positions: Array<Pick<Position, 'id' | 'keyword'>>;
     skills: Array<Pick<Skill, 'id' | 'keyword'>>;
     sources: Array<Pick<Source, 'id' | 'type' | 'url' | 'subtype' | 'createdAt'>>;
-    experiences: Array<
-      Pick<Experience, 'id' | 'companyName' | 'startDate' | 'endDate' | 'position' | 'description' | 'createdAt'>
-    >;
+    experiences: Array<Experience.GetResponse>;
     experienceYears: number & tags.Type<'int64'>;
     roomCount: number & tags.Type<'int64'>;
   }

--- a/src/interfaces/experiences.interface.ts
+++ b/src/interfaces/experiences.interface.ts
@@ -17,10 +17,7 @@ export namespace Experience {
    * create
    */
   export interface CreateData
-    extends Pick<
-        Experience,
-        'companyName' | 'position' | 'startDate' | 'endDate' | 'sequence'
-      >,
+    extends Pick<Experience, 'companyName' | 'position' | 'startDate' | 'endDate' | 'sequence'>,
       Partial<Pick<Experience, 'description'>> {}
 
   export interface CreateRequest {
@@ -33,14 +30,6 @@ export namespace Experience {
   export interface GetResponse
     extends Pick<
       Experience,
-      | 'id'
-      | 'companyName'
-      | 'position'
-      | 'description'
-      | 'startDate'
-      | 'sequence'
-      | 'endDate'
+      'id' | 'companyName' | 'position' | 'description' | 'startDate' | 'sequence' | 'endDate' | 'createdAt'
     > {}
-
-  export interface GetAllResponse extends Array<GetResponse> {}
 }

--- a/src/interfaces/experiences.interface.ts
+++ b/src/interfaces/experiences.interface.ts
@@ -16,12 +16,12 @@ export namespace Experience {
   /**
    * create
    */
-  export interface CreateData
+  export interface CreateRequest
     extends Pick<Experience, 'companyName' | 'position' | 'startDate' | 'endDate' | 'sequence'>,
       Partial<Pick<Experience, 'description'>> {}
 
-  export interface CreateRequest {
-    experiences: Array<CreateData> & tags.MinItems<1>;
+  export interface CreateManyRequest {
+    experiences: Array<CreateRequest> & tags.MinItems<1>;
   }
 
   /**
@@ -32,4 +32,11 @@ export namespace Experience {
       Experience,
       'id' | 'companyName' | 'position' | 'description' | 'startDate' | 'sequence' | 'endDate' | 'createdAt'
     > {}
+
+  /**
+   * update
+   */
+  export interface UpdateRequest extends Omit<CreateRequest, 'sequence'> {}
+
+  export interface UpdateResponse extends Pick<Experience, 'id'> {}
 }

--- a/src/modules/characters.module.ts
+++ b/src/modules/characters.module.ts
@@ -3,9 +3,10 @@ import { CharactersService } from 'src/services/characters.service';
 import { CharactersController } from '../controllers/characters.controller';
 import { PositionsModule } from './positions.module';
 import { SkillsModule } from './skills.module';
+import { ExperiencesModule } from './experiences.module';
 
 @Module({
-  imports: [PositionsModule, SkillsModule],
+  imports: [ExperiencesModule, PositionsModule, SkillsModule],
   controllers: [CharactersController],
   providers: [CharactersService],
   exports: [CharactersService],

--- a/src/modules/experiences.module.ts
+++ b/src/modules/experiences.module.ts
@@ -5,5 +5,6 @@ import { ExperiencesController } from '../controllers/experiences.controller';
 @Module({
   controllers: [ExperiencesController],
   providers: [ExperiencesService],
+  exports: [ExperiencesService],
 })
 export class ExperiencesModule {}

--- a/src/services/experiences.service.ts
+++ b/src/services/experiences.service.ts
@@ -65,13 +65,13 @@ export class ExperiencesService {
     const { experiences } = body;
     const date = DateTimeUtil.now();
 
-    const id = randomUUID();
-    const snapshotId = randomUUID();
-
     const newExperiences = await this.prisma.$transaction(async (tx) => {
       return await Promise.all(
-        experiences.map((el) =>
-          tx.experience.create({
+        experiences.map((el) => {
+          const id = randomUUID();
+          const snapshotId = randomUUID();
+
+          return tx.experience.create({
             select: this.createSelectInput(),
             data: {
               id: id,
@@ -95,8 +95,8 @@ export class ExperiencesService {
                 },
               },
             },
-          }),
-        ),
+          });
+        }),
       );
     });
 

--- a/src/services/experiences.service.ts
+++ b/src/services/experiences.service.ts
@@ -154,6 +154,18 @@ export class ExperiencesService {
     return { id };
   }
 
+  async delete(memberId: string, id: Experience['id']): Promise<Experience.UpdateResponse> {
+    const experience = await this.get(memberId, id);
+    const date = DateTimeUtil.now();
+
+    await this.prisma.experience.update({
+      where: { id },
+      data: { deleted_at: date },
+    });
+
+    return { id };
+  }
+
   private async updateSnapshot(
     id: Experience['id'],
     sequence: Experience['sequence'],

--- a/test/e2e/experiences.e2e.spec.ts
+++ b/test/e2e/experiences.e2e.spec.ts
@@ -1,12 +1,16 @@
-import { IConnection } from '@nestia/fetcher';
-import { INestApplication } from '@nestjs/common';
+import { HttpError, IConnection } from '@nestia/fetcher';
+import { INestApplication, NotFoundException } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { randomInt } from 'crypto';
 import { AppModule } from 'src/app.module';
 import { Experience } from 'src/interfaces/experiences.interface';
 import { test_api_refresh } from 'test/features/auth/test_api_refresh';
 import { test_api_createExperiences } from 'test/features/experiences/test_api_createExperiences';
+import { test_api_deleteExperience } from 'test/features/experiences/test_api_deleteExperience';
 import { test_api_getAllExperiences } from 'test/features/experiences/test_api_getAllExperiences';
+import { test_api_getExperience } from 'test/features/experiences/test_api_getExperience';
+import { test_api_updateExperience } from 'test/features/experiences/test_api_updateExperience';
+import typia from 'typia';
 
 describe('Experiences Test', () => {
   let app: INestApplication;
@@ -60,5 +64,45 @@ describe('Experiences Test', () => {
   it('경력들을 조회한다. 앞서 생성되었기 때문에 경력은 1개 이상 조회되어야 한다.', async () => {
     const experiences = await test_api_getAllExperiences(connection);
     expect(experiences.length > 1).toBe(true);
+  });
+
+  it('경력을 수정한다. id를 기반으로 조회하고 수정할 수 있어야 한다.', async () => {
+    // 1. test 경력을 한 개 생성한다.
+    const newExperiences = await test_api_createExperiences(connection);
+    const testExperience = newExperiences?.at(0);
+    expect(testExperience).toBeDefined();
+
+    const testId = testExperience?.id as string;
+
+    // 2. test 경력을 조회한다.
+    const experience = await test_api_getExperience(connection, testId);
+
+    // 3. 경력데이터를 수정한다.
+    const updateInput: Experience.UpdateRequest = {
+      companyName: `companyName`,
+      startDate: `2020-12-01`,
+      endDate: `2022-12-01`,
+      position: 'FrontEnd',
+      description: `description`,
+    };
+    await test_api_updateExperience(connection, testId, updateInput);
+
+    // 4. test 경력을 다시 조회한다.
+    const updatedExperience = await test_api_getExperience(connection, testId);
+
+    expect(experience).not.toBe(updatedExperience);
+  });
+
+  it('경력을 삭제한다. 삭제되었다면 조회할 수 없어야 한다.', async () => {
+    // 1. test 경력을 한 개 생성한다.
+    const newExperiences = await test_api_createExperiences(connection);
+    const testExperience = newExperiences?.at(0);
+    expect(testExperience).toBeDefined();
+
+    const testId = testExperience?.id as string;
+    await test_api_deleteExperience(connection, testId);
+
+    // 2. 삭제 후 조회했을 때 NotFoundException이 발생해야 한다.
+    await expect(test_api_getExperience(connection, testId)).rejects.toBeInstanceOf(HttpError);
   });
 });

--- a/test/e2e/experiences.e2e.spec.ts
+++ b/test/e2e/experiences.e2e.spec.ts
@@ -41,7 +41,7 @@ describe('Experiences Test', () => {
 
   it('경력을 생성한다. 1개 이상의 경력을 생성할 수 있어야 한다.', async () => {
     const inputLength = 3; // 여기서는 3개의 경력을 생성한다.
-    const input: Experience.CreateRequest = {
+    const input: Experience.CreateManyRequest = {
       experiences: new Array(inputLength).fill(0).map((el, index) => {
         return {
           companyName: `test_companyName_${index}`,

--- a/test/features/experiences/test_api_createExperiences.ts
+++ b/test/features/experiences/test_api_createExperiences.ts
@@ -18,4 +18,6 @@ export const test_api_createExperiences = async (connection: api.IConnection, in
 
   const output = await api.functional.experiences.createExperiences(connection, newInput);
   typia.assert(output);
+
+  return output;
 };

--- a/test/features/experiences/test_api_createExperiences.ts
+++ b/test/features/experiences/test_api_createExperiences.ts
@@ -2,8 +2,8 @@ import api from 'src/api';
 import { Experience } from 'src/interfaces/experiences.interface';
 import typia from 'typia';
 
-export const test_api_createExperiences = async (connection: api.IConnection, input?: Experience.CreateRequest) => {
-  const newInput: Experience.CreateRequest = input ?? {
+export const test_api_createExperiences = async (connection: api.IConnection, input?: Experience.CreateManyRequest) => {
+  const newInput: Experience.CreateManyRequest = input ?? {
     experiences: new Array(1).fill(0).map((el, index) => {
       return {
         companyName: `test_companyName_${index}`,

--- a/test/features/experiences/test_api_deleteExperience.ts
+++ b/test/features/experiences/test_api_deleteExperience.ts
@@ -1,0 +1,10 @@
+import api from 'src/api';
+import { Experience } from 'src/interfaces/experiences.interface';
+import typia from 'typia';
+
+export const test_api_deleteExperience = async (connection: api.IConnection, id: Experience['id']) => {
+  const output = await api.functional.experiences.deleteExperience(connection, id);
+  typia.assert(output);
+
+  return output;
+};

--- a/test/features/experiences/test_api_getExperience.ts
+++ b/test/features/experiences/test_api_getExperience.ts
@@ -1,0 +1,10 @@
+import api from 'src/api';
+import { Experience } from 'src/interfaces/experiences.interface';
+import typia from 'typia';
+
+export const test_api_getExperience = async (connection: api.IConnection, id: Experience['id']) => {
+  const output = await api.functional.experiences.getExperience(connection, id);
+  typia.assert(output);
+
+  return output;
+};

--- a/test/features/experiences/test_api_updateExperience.ts
+++ b/test/features/experiences/test_api_updateExperience.ts
@@ -1,0 +1,14 @@
+import api from 'src/api';
+import { Experience } from 'src/interfaces/experiences.interface';
+import typia from 'typia';
+
+export const test_api_updateExperience = async (
+  connection: api.IConnection,
+  id: Experience['id'],
+  body: Experience.UpdateRequest,
+) => {
+  const output = await api.functional.experiences.updateExperience(connection, id, body);
+  typia.assert(output);
+
+  return output;
+};


### PR DESCRIPTION
## Experience 수정 삭제 API를 구현합니다.
- Experience 모델을 스냅샷 구조로 변경하였습니다. (DB 구조 변경됨)

### 📌 관련 이슈

### ✏️ 변경 사항

1. Experience 모델을 스냅샷 구조 적용
- 경력 사항의 경우, 변경 이력을 추적할 수 있도록 스냅샷 구조를 적용하였습니다.

2. 구조 변경으로 인한 API 수정
- 다음 API 내부 로직들이 영향을 받아 리팩토링을 진행했습니다.
- `Post characters/` : 캐릭터 생성
- `Get characters/` : 캐릭터 리스트 조회
- `Get characters/:id` : 캐릭터 상세 조회
- `Post experiences/` : 경력 다수 생성
- `Get experiences/` : 경력 리스트 조회

3. 경력관련 API를 추가했습니다.
- 다음 API를 구현하고 테스트 코드를 작성하였습니다.
- `Get experiences/:id` : 경력 조회 API, 아이디를 기준으로 경력을 조회합니다.
- `Patch experiences/:id`: 경력 수정 API, 내부적으로 새로운 스냅샷을 생성합니다. 
- `Delete experiences/:id`: 경력 삭제 API, 경력을 soft-delete 처리 합니다. 더 이상 조회되지 않습니다.