### PR TITLE
[Feat] notion verify / get & update & delete source

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -80,8 +80,12 @@ export class AuthController {
    */
   @UseGuards(UserGuard)
   @core.TypedRoute.Get('notion/verify')
-  async notionVerify(@User() user: Guard.UserResponse): Promise<true> {
-    await this.authService.getNotionAccessTokenByUserId(user.id);
-    return true;
+  async notionVerify(@User() user: Guard.UserResponse): Promise<boolean> {
+    try {
+      await this.authService.getNotionAccessTokenByUserId(user.id);
+      return true;
+    } catch (err) {
+      return false;
+    }
   }
 }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -81,7 +81,7 @@ export class AuthController {
   @UseGuards(UserGuard)
   @core.TypedRoute.Get('notion/verify')
   async notionVerify(@User() user: Guard.UserResponse): Promise<true> {
-    await this.authService.getNotionAccessToken(user.id);
+    await this.authService.getNotionAccessTokenByUserId(user.id);
     return true;
   }
 }

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -27,7 +27,7 @@ export class SourcesController {
   async createSource(
     @core.TypedParam('characterId') characterId: Source['characterId'],
     @core.TypedBody() body: Source.CreateRequest,
-  ) {
+  ): Promise<Source.GetResponse> {
     return await this.sourcesService.create(characterId, body);
   }
 
@@ -108,6 +108,8 @@ export class SourcesController {
 
   /**
    * 노션 링크를 받아 콘텐츠를 읽어 마크다운 문자열로 변환한다.
+   *
+   * @security x-member bearer
    */
   @UseGuards(MemberGuard)
   @core.TypedRoute.Post('/notion/markdown')

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -41,7 +41,7 @@ export class SourcesController {
   async createSources(
     @core.TypedParam('characterId') characterId: Source['characterId'],
     @core.TypedBody() body: Array<Source.CreateRequest>,
-  ): Promise<Source.CreateManyResponse> {
+  ): Promise<Source.GetAllResponse> {
     return await this.sourcesService.createMany(characterId, body);
   }
 

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -1,14 +1,21 @@
 import core from '@nestia/core';
 import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
+import { Guard } from 'src/interfaces/guard.interface';
 import { Source } from 'src/interfaces/source.interface';
+import { NotionService } from 'src/services/notion.service';
 import { SourcesService } from 'src/services/sources.service';
+import { NotionUtil } from 'src/util/notion.util';
 
 @ApiTags('Source')
 @Controller('sources')
 export class SourcesController {
-  constructor(private readonly sourcesService: SourcesService) {}
+  constructor(
+    private readonly sourcesService: SourcesService,
+    private readonly notionService: NotionService,
+  ) {}
 
   /**
    * 소스를 저장한다. 소스는 link, file 타입으로 나뉘며 자기소개서나, 이력서를 받을때 사용한다.
@@ -44,5 +51,27 @@ export class SourcesController {
   @core.TypedRoute.Get('/:characterId')
   async getSources(@core.TypedParam('characterId') characterId: Source['characterId']): Promise<Source.GetAllResponse> {
     return await this.sourcesService.getAll(characterId);
+  }
+
+  /**
+   * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception이 발생한다.
+   */
+  @core.TypedRoute.Get('/notion/verify')
+  async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<NotionUtil.VerifyUrlResponse> {
+    const pageId = this.notionService.verifyNotionUrl(body.url);
+    return { pageId };
+  }
+
+  /**
+   * 노션 링크를 받아 콘텐츠를 읽어 마크다운 문자열로 변환한다.
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get('/notion/markdown')
+  async notionToMarkdown(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedBody() body: Pick<Source, 'url'>,
+  ): Promise<NotionUtil.ToMarkdownResponse> {
+    const content = await this.notionService.notionToMarkdownByMemberId(member.id, body.url);
+    return { content };
   }
 }

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -56,7 +56,7 @@ export class SourcesController {
   /**
    * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception이 발생한다.
    */
-  @core.TypedRoute.Get('/notion/verify')
+  @core.TypedRoute.Post('/notion/verify')
   async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<NotionUtil.VerifyUrlResponse> {
     const pageId = this.notionService.verifyNotionUrl(body.url);
     return { pageId };
@@ -66,7 +66,7 @@ export class SourcesController {
    * 노션 링크를 받아 콘텐츠를 읽어 마크다운 문자열로 변환한다.
    */
   @UseGuards(MemberGuard)
-  @core.TypedRoute.Get('/notion/markdown')
+  @core.TypedRoute.Post('/notion/markdown')
   async notionToMarkdown(
     @Member() member: Guard.MemberResponse,
     @core.TypedBody() body: Pick<Source, 'url'>,

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -57,6 +57,22 @@ export class SourcesController {
   }
 
   /**
+   * 캐릭터의 특정 소스를 수정한다. 변경된 내용이 있을때만 수정한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Patch('/:characterId/:id')
+  async updateSource(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('characterId') characterId: Source['characterId'],
+    @core.TypedParam('id') id: Source['id'],
+    @core.TypedBody() body: Source.UpdateRequest,
+  ) {
+    return await this.sourcesService.update(member.id, characterId, id, body);
+  }
+
+  /**
    * 캐릭터에 저장된 소스들을 조회한다.
    */
   @core.TypedRoute.Get('/:characterId')

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -69,7 +69,8 @@ export class SourcesController {
     @core.TypedParam('id') id: Source['id'],
     @core.TypedBody() body: Source.UpdateRequest,
   ) {
-    return await this.sourcesService.update(member.id, characterId, id, body);
+    const updatedSource = await this.sourcesService.update(member.id, characterId, id, body);
+    return updatedSource ?? { message: '변경된 내용이 없습니다.' };
   }
 
   /**

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -101,9 +101,9 @@ export class SourcesController {
    * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception이 발생한다.
    */
   @core.TypedRoute.Post('/notion/verify')
-  async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<NotionUtil.VerifyUrlResponse> {
-    const pageId = this.notionService.verifyNotionUrl(body.url);
-    return { pageId };
+  async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<boolean> {
+    const pageId = this.notionService.getPrivateNotionId(body.url);
+    return pageId ? true : false;
   }
 
   /**

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -74,6 +74,22 @@ export class SourcesController {
   }
 
   /**
+   * 캐릭터의 특정 소스를 삭제한다. (soft-del)
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Delete('/:characterId/:id')
+  async deleteSource(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('characterId') characterId: Source['characterId'],
+    @core.TypedParam('id') id: Source['id'],
+  ) {
+    await this.sourcesService.delete(member.id, characterId, id);
+    return { message: '첨부 파일이 삭제되었습니다. ' };
+  }
+
+  /**
    * 캐릭터에 저장된 소스들을 조회한다.
    */
   @core.TypedRoute.Get('/:characterId')

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -98,12 +98,15 @@ export class SourcesController {
   }
 
   /**
-   * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception이 발생한다.
+   * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception -> false 값을 반환한다.
    */
   @core.TypedRoute.Post('/notion/verify')
   async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<boolean> {
-    const pageId = this.notionService.getPrivateNotionId(body.url);
-    return pageId ? true : false;
+    try {
+      this.notionService.verifyNotionUrl(body.url);
+      return true;
+    } catch (err) {}
+    return false;
   }
 
   /**

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -46,6 +46,17 @@ export class SourcesController {
   }
 
   /**
+   * 캐릭터의 특정 소스를 조회한다.
+   */
+  @core.TypedRoute.Get('/:characterId/:id')
+  async getSource(
+    @core.TypedParam('characterId') characterId: Source['characterId'],
+    @core.TypedParam('id') id: Source['id'],
+  ): Promise<Source.GetResponse> {
+    return await this.sourcesService.get(characterId, id);
+  }
+
+  /**
    * 캐릭터에 저장된 소스들을 조회한다.
    */
   @core.TypedRoute.Get('/:characterId')

--- a/src/interfaces/source.interface.ts
+++ b/src/interfaces/source.interface.ts
@@ -25,4 +25,9 @@ export namespace Source {
   export interface GetAllResponse extends Pick<Source, 'characterId'> {
     sources: Array<GetResponse>;
   }
+
+  /**
+   * update
+   */
+  export interface UpdateRequest extends CreateRequest {}
 }

--- a/src/interfaces/source.interface.ts
+++ b/src/interfaces/source.interface.ts
@@ -15,20 +15,12 @@ export namespace Source {
   /**
    * create
    */
-  export interface CreateRequest
-    extends Pick<Source, 'type' | 'subtype' | 'url'> {}
+  export interface CreateRequest extends Pick<Source, 'type' | 'subtype' | 'url'> {}
 
-  export interface CreateResponse extends Pick<Source, 'id'> {}
-
-  export interface CreateManyResponse {
-    count: number;
-  }
   /**
    * get
    */
-
-  export interface GetResponse
-    extends Pick<Source, 'id' | 'type' | 'subtype' | 'url' | 'createdAt'> {}
+  export interface GetResponse extends Pick<Source, 'id' | 'type' | 'subtype' | 'url' | 'createdAt'> {}
 
   export interface GetAllResponse extends Pick<Source, 'characterId'> {
     sources: Array<GetResponse>;

--- a/src/modules/chats.module.ts
+++ b/src/modules/chats.module.ts
@@ -4,9 +4,10 @@ import { PromptsService } from 'src/services/prompts.service';
 import { ChatsService } from '../services/chats.service';
 import { CharactersModule } from './characters.module';
 import { RoomsModule } from './rooms.module';
+import { SourcesModule } from './sources.module';
 
 @Module({
-  imports: [RoomsModule, CharactersModule],
+  imports: [RoomsModule, CharactersModule, SourcesModule],
   controllers: [ChatsController],
   providers: [ChatsService, PromptsService],
   exports: [ChatsService],

--- a/src/modules/sources.module.ts
+++ b/src/modules/sources.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SourcesController } from 'src/controllers/sources.controller';
+import { NotionService } from 'src/services/notion.service';
 import { SourcesService } from '../services/sources.service';
 
 @Module({
   controllers: [SourcesController],
-  providers: [SourcesService],
+  providers: [SourcesService, NotionService],
+  exports: [NotionService],
 })
 export class SourcesModule {}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -69,7 +69,7 @@ export class AuthService {
       return this.login(member);
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('구글 로그인에 실패했습니다.');
     }
   }
 
@@ -100,7 +100,7 @@ export class AuthService {
       });
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('노션 연동에 실패했습니다.');
     }
   }
 
@@ -244,7 +244,7 @@ export class AuthService {
     });
 
     if (!member || !member.member_id) {
-      throw new NotFoundException();
+      throw new NotFoundException('멤버 정보가 존재하지 않습니다.');
     }
 
     return { memberId: member.member_id };
@@ -258,7 +258,7 @@ export class AuthService {
       return payload as { id: string; name: string };
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException();
+      throw new UnauthorizedException('잘못된 토큰입니다.');
     }
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -106,20 +106,27 @@ export class AuthService {
 
   /**
    * 해당 유저와 연관된 멤버에게 notion provider 조회결과가 있는지 확인한다.
+   * @param userId
    */
-  async getNotionAccessToken(userId: string): Promise<Pick<Provider, 'id' | 'password'>> {
-    const member = await this.getMember(userId);
+  async getNotionAccessTokenByUserId(userId: string): Promise<Pick<Provider, 'id' | 'password'>> {
+    const { memberId } = await this.getMember(userId);
+    return await this.getNotionAccessTokenByMemberId(memberId);
+  }
 
+  /**
+   * 해당 멤버의 notion provider 조회 결과가 있는지 확인한다.
+   */
+  async getNotionAccessTokenByMemberId(memberId: string): Promise<Pick<Provider, 'id' | 'password'>> {
     const provider = await this.prisma.provider.findFirst({
       select: { id: true, password: true },
       where: {
-        member_id: member.memberId,
+        member_id: memberId,
         type: 'notion',
       },
     });
 
     if (!provider) {
-      throw new NotFoundException();
+      throw new NotFoundException('노션 연동정보가 존재하지 않습니다.');
     }
 
     return provider;

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -139,7 +139,10 @@ export class CharactersService {
             },
           },
         },
-        sources: { select: { id: true, type: true, subtype: true, url: true, created_at: true } },
+        sources: {
+          select: { id: true, type: true, subtype: true, url: true, created_at: true },
+          where: { deleted_at: null },
+        },
         character_personalites: {
           select: {
             personality: {

--- a/src/services/notion.service.ts
+++ b/src/services/notion.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Client } from '@notionhq/client';
+import { NotionToMarkdown } from 'notion-to-md';
+import { Source } from 'src/interfaces/source.interface';
+import { NotionUtil } from 'src/util/notion.util';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class NotionService {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * 프라이빗 노션 링크인지 검증한다.
+   * id가 정규식에 의해 추출된다면 반환하고, 아니라면 Exception이 발생한다.
+   *
+   * @param url 검증할 url
+   */
+  verifyNotionUrl(url: Source['url']): string {
+    const id = this.getPrivateNotionId(url);
+
+    if (!id) {
+      throw new NotFoundException('지원하는 노션 url 형식이 아닙니다.');
+    }
+    return id;
+  }
+
+  /**
+   * 멤버 아이디를 바탕으로 노션 연동정보를 확인하고 페이지 콘텐츠를 마크다운으로 변환한다.
+   * @param memberId
+   * @param url 노션 연동 확인을 위한
+   */
+  async notionToMarkdownByMemberId(memberId: string, url: Source['url']): Promise<string> {
+    const id = this.verifyNotionUrl(url);
+    const { password: accessToken } = await this.authService.getNotionAccessTokenByMemberId(memberId);
+
+    return await this.getNotionToMd(accessToken, id);
+  }
+
+  /**
+   * 유저 아이디를 바탕으로 노션 연동정보를 확인하고 페이지 콘텐츠를 마크다운으로 변환한다.
+   * @param userId
+   * @param url 노션 연동 확인을 위한
+   */
+  async notionToMarkdownByUserId(memberId: string, url: Source['url']): Promise<string> {
+    const id = this.verifyNotionUrl(url);
+    const { password: accessToken } = await this.authService.getNotionAccessTokenByUserId(memberId);
+
+    return await this.getNotionToMd(accessToken, id);
+  }
+
+  /**
+   * 노션 private url에서 페이지의 id를 추출한다.
+   *
+   * private url 형식이 아니거나 id가 추출되지 않으면 null을 반환한다.
+   */
+  private getPrivateNotionId(url: string): string | null {
+    const match = url.match(NotionUtil.privateNotionIdRegex);
+    return match ? match[2] : null;
+  }
+
+  /**
+   * NotionToMd 라이브러리를 사용해 노션 콘텐츠를 마크다운으로 변경한다.
+   *
+   * https://www.npmjs.com/package/notion-to-md
+   *
+   * @param accessToken 노션 OAuth Access Token
+   * @param id 변환할 노션 페이지의 아이디
+   */
+  private async getNotionToMd(accessToken: string, id: string): Promise<string> {
+    try {
+      const notionClient = new Client({ auth: accessToken });
+      const n2m = new NotionToMarkdown({ notionClient, config: { separateChildPage: false } });
+      const mdblocks = await n2m.pageToMarkdown(id);
+      const mdString = n2m.toMarkdownString(mdblocks);
+
+      return mdString?.parent ?? '';
+    } catch (err) {
+      throw new NotFoundException('노션 콘텐츠 마크다운 변환에 실패했습니다.');
+    }
+  }
+}

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -107,12 +107,12 @@ export class SourcesService {
     characterId: Source['characterId'],
     id: Source['id'],
     body: Source.UpdateRequest,
-  ) {
+  ): Promise<Source.GetResponse | null> {
     const source = await this.get(characterId, id, { memberId: memberId });
     const isChanged = ObjectUtil.isChanged(source, body);
 
     if (!isChanged) {
-      return { message: '변경된 내용이 없습니다.' };
+      return null;
     }
 
     const updatedSource = await this.prisma.source.update({

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Source } from 'src/interfaces/source.interface';
@@ -58,6 +58,29 @@ export class SourcesService {
     const sources = data.map((el): Source.GetResponse => this.mapping(el));
 
     return { characterId, sources };
+  }
+
+  /**
+   * 캐릭터에 저장된 특정 소스를 조회한다.
+   */
+  async get(characterId: Source['characterId'], id: Source['id']): Promise<Source.GetResponse> {
+    const source = await this.prisma.source.findUnique({
+      select: {
+        id: true,
+        type: true,
+        subtype: true,
+        url: true,
+        created_at: true,
+      },
+
+      where: { id, character_id: characterId, deleted_at: null },
+    });
+
+    if (!source) {
+      throw new NotFoundException('존재하지 않는 소스 입니다.');
+    }
+
+    return this.mapping(source);
   }
 
   /**

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -93,7 +93,7 @@ export class SourcesService {
     });
 
     if (!source) {
-      throw new NotFoundException('존재하지 않는 소스 입니다.');
+      throw new NotFoundException('존재하지 않는 첨부파일 입니다.');
     }
 
     return this.mapping(source);
@@ -132,6 +132,28 @@ export class SourcesService {
     });
 
     return this.mapping(updatedSource);
+  }
+
+  /**
+   * 소스를 삭제한다.
+   */
+  async delete(memberId: Member['id'], characterId: Source['characterId'], id: Source['id']): Promise<void> {
+    const date = DateTimeUtil.now();
+    await this.get(characterId, id, { memberId: memberId });
+
+    await this.prisma.source.update({
+      select: {
+        id: true,
+        type: true,
+        subtype: true,
+        url: true,
+        created_at: true,
+      },
+      where: { id: id },
+      data: {
+        deleted_at: date,
+      },
+    });
   }
 
   /**

--- a/src/util/notion.util.ts
+++ b/src/util/notion.util.ts
@@ -23,13 +23,6 @@ export namespace NotionUtil {
   }
 
   /**
-   * 노션 페이지 아이디 응답값
-   */
-  export interface VerifyUrlResponse {
-    pageId: string;
-  }
-
-  /**
    * 노션 페이지 마크다운 변환 응답값
    */
   export interface ToMarkdownResponse {

--- a/src/util/notion.util.ts
+++ b/src/util/notion.util.ts
@@ -23,6 +23,20 @@ export namespace NotionUtil {
   }
 
   /**
+   * 노션 페이지 아이디 응답값
+   */
+  export interface VerifyUrlResponse {
+    pageId: string;
+  }
+
+  /**
+   * 노션 페이지 마크다운 변환 응답값
+   */
+  export interface ToMarkdownResponse {
+    content: string;
+  }
+
+  /**
    * 노션 프라이빗 페이지 아이디 추출 정규식
    */
   export const privateNotionIdRegex = /https?:\/\/(www\.)?notion\.so\/(?:[^/]+\/)?[^\s/]*?([a-f0-9]{32})(?:\?[^\s]*)?$/;

--- a/src/util/notion.util.ts
+++ b/src/util/notion.util.ts
@@ -1,4 +1,7 @@
 export namespace NotionUtil {
+  /**
+   * 노션 OAuth 인증 응답값
+   */
   export interface AuthorizationResponse {
     access_token: string;
     bot_id: string;
@@ -19,14 +22,8 @@ export namespace NotionUtil {
     workspace_icon?: string;
   }
 
-  const privateNotionIdRegex = /https?:\/\/(www\.)?notion\.so\/(?:[^/]+\/)?[^\s/]*?([a-f0-9]{32})(?:\?[^\s]*)?$/;
-
   /**
-   * 노션 private url에서 id 부분을 반환한다.
-   * private url 형식이 아니거나, id가 추출되지 않으면 null을 반환한다.
+   * 노션 프라이빗 페이지 아이디 추출 정규식
    */
-  export function getPrivateNotionId(url: string): string | null {
-    const match = url.match(privateNotionIdRegex);
-    return match ? match[2] : null;
-  }
+  export const privateNotionIdRegex = /https?:\/\/(www\.)?notion\.so\/(?:[^/]+\/)?[^\s/]*?([a-f0-9]{32})(?:\?[^\s]*)?$/;
 }

--- a/src/util/object.util.ts
+++ b/src/util/object.util.ts
@@ -1,0 +1,31 @@
+export namespace ObjectUtil {
+  /**
+   * 빈 객체인지 검증한다.
+   */
+  export const isEmpty = (obj: object) => Object.keys(obj).length === 0;
+
+  /**
+   * original의 키를 기준으로 순회하며 updated에 다른 내용이 있는지 확인한다.
+   * 변경된 내용이 있다면 true, 없다면 false를 반환한다.
+   */
+  export function isChanged<T extends Record<string, any>>(original: T, updated: Partial<T>): boolean {
+    const changedFields = ObjectUtil.getChangedFields(original, updated);
+    return isEmpty(changedFields) ? false : true;
+  }
+
+  /**
+   * updated의 키를 기준으로 순회하며 original에 갱신된 내용이 있는지 확인한다.
+   * 변경된 키와 값을 반환한다.
+   *
+   * @param original T → 원본 객체
+   * @param updated Partial<T> → 수정된 객체 (일부 필드만 포함 가능)
+   */
+  export function getChangedFields<T extends Record<string, any>>(original: T, updated: Partial<T>): Partial<T> {
+    return Object.entries(updated).reduce((acc, [key, value]) => {
+      if (original[key] !== value) {
+        acc[key as keyof T] = value;
+      }
+      return acc;
+    }, {} as Partial<T>);
+  }
+}


### PR DESCRIPTION
## 소스 관련 API를 고도화 합니다.
- 구현되어 있던 API의 응답 값과 에러메시지를 확장하였습니다.
- 수정 및 삭제 API를 추가합니다.
- 노션 검증 관련 API를 추가합니다.


### 📌 관련 이슈

- 여기에 관련 이슈들을 나열해 주세요. 없다면 비워두어도 괜찮습니다.

### ✏️ 변경 사항

1. 노션 url 검증 API 추가 `Post /sources/notion/verify`
- 지원하는 노션 링크 형식인지 확인합니다.
- 반환값은 true, false 입니다.

2. 노션 마크다운 변환 API 추가 `Post /sources/notion/verify`
- 노션 페이지의 콘텐츠를 마크다운으로 변환합니다.
- 해당 페이지에 대한 노션 연동 및 읽기 권한이 활성화 되어있어야 합니다.
- x-member 헤더를 요구합니다.

3. 캐릭터의 특정 소스 조회/수정/삭제 API 추가
- `Get /sources/:characterId/:id`
- `Patch /sources/:characterId/:id`: x-member 헤더를 요구합니다.
- `Delete /sources/:characterId/:id`: x-member 헤더를 요구합니다.
- 사용자가 캐릭터에 저장한 첨부파일을 각각 관리할 수 있도록 합니다.

4. 기타
- Auth 관련 서비스 로직에 주석 및 에러메시지 상세히 기술
- 캐릭터 조회 시 삭제한 source 정보를 조회하지 않도록 수정 
- 객체 관련 유틸함수들을 모아둘 ObjectUtil 추가