### PR TITLE
[Feat] get all personality

### DIFF
--- a/src/controllers/personalities.controller.ts
+++ b/src/controllers/personalities.controller.ts
@@ -1,7 +1,6 @@
 import core from '@nestia/core';
-import { Controller, UseGuards } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { MemberGuard } from 'src/guards/member.guard';
 import { Personality } from 'src/interfaces/personalities.interface';
 import { PersonalitiesService } from 'src/services/personalities.service';
 
@@ -11,12 +10,20 @@ export class PersonalitiesController {
   constructor(private readonly personalitiesService: PersonalitiesService) {}
 
   /**
+   * 성격을 전체 조회한다.
+   */
+  @core.TypedRoute.Get('/all')
+  async getPersonalities(): Promise<Array<Personality.GetResponse>> {
+    return this.personalitiesService.getAll();
+  }
+
+  /**
    * 성격을 페이지네이션으로 조회한다.
    */
   @core.TypedRoute.Get()
   async getPersonalitiesByPage(
     @core.TypedQuery() query: Personality.GetByPageRequest,
-  ): Promise<Personality.GetByPageResonse> {
+  ): Promise<Personality.GetByPageResponse> {
     return this.personalitiesService.getByPage(query);
   }
 }

--- a/src/interfaces/personalities.interface.ts
+++ b/src/interfaces/personalities.interface.ts
@@ -21,8 +21,7 @@ export namespace Personality {
   /**
    * get
    */
-  export interface GetByPageData extends Pick<Personality, 'id' | 'keyword'> {}
+  export interface GetResponse extends Pick<Personality, 'id' | 'keyword' | 'createdAt'> {}
 
-  export interface GetByPageResonse
-    extends PaginationUtil.Response<GetByPageData> {}
+  export interface GetByPageResponse extends PaginationUtil.Response<GetResponse> {}
 }

--- a/src/services/personalities.service.ts
+++ b/src/services/personalities.service.ts
@@ -37,6 +37,8 @@ export class PersonalitiesService {
   async getAll(): Promise<Array<Personality.GetResponse>> {
     const personalities = await this.prisma.personality.findMany({
       select: { id: true, keyword: true, created_at: true },
+      where: { deleted_at: null },
+      orderBy: { keyword: 'asc' },
     });
 
     /**
@@ -58,6 +60,7 @@ export class PersonalitiesService {
       this.prisma.personality.findMany({
         select: { id: true, keyword: true, created_at: true },
         where: whereInput,
+        orderBy: { keyword: 'asc' },
         skip,
         take,
       }),

--- a/src/services/personalities.service.ts
+++ b/src/services/personalities.service.ts
@@ -1,15 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from './prisma.service';
-import { Personality } from 'src/interfaces/personalities.interface';
 import { Prisma } from '@prisma/client';
-import { PaginationUtil } from 'src/util/pagination.util';
-import { DateTimeUtil } from 'src/util/date-time.util';
 import { randomUUID } from 'crypto';
+import { Personality } from 'src/interfaces/personalities.interface';
+import { DateTimeUtil } from 'src/util/date-time.util';
+import { PaginationUtil } from 'src/util/pagination.util';
+import { PrismaService } from './prisma.service';
 
 @Injectable()
 export class PersonalitiesService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * 성격을 다수 생성합니다. (현재 어드민용)
+   */
   async createBulk(body: Personality.CreateBulkRequest): Promise<void> {
     const { keywords } = body;
     const date = DateTimeUtil.now();
@@ -28,13 +31,32 @@ export class PersonalitiesService {
     });
   }
 
-  async getByPage(query: Personality.GetByPageRequest): Promise<Personality.GetByPageResonse> {
+  /**
+   * 성격을 전체 조회합니다.
+   */
+  async getAll(): Promise<Array<Personality.GetResponse>> {
+    const personalities = await this.prisma.personality.findMany({
+      select: { id: true, keyword: true, created_at: true },
+    });
+
+    /**
+     * mapping
+     */
+    return personalities.map((el): Personality.GetResponse => {
+      return { id: el.id, keyword: el.keyword, createdAt: el.created_at.toISOString() };
+    });
+  }
+
+  /**
+   * 성격을 페이지네이션으로 조회합니다.
+   */
+  async getByPage(query: Personality.GetByPageRequest): Promise<Personality.GetByPageResponse> {
     const { skip, take } = PaginationUtil.getOffset(query);
     const whereInput: Prisma.PersonalityWhereInput = { deleted_at: null };
 
     const [personalities, count] = await this.prisma.$transaction([
       this.prisma.personality.findMany({
-        select: { id: true, keyword: true },
+        select: { id: true, keyword: true, created_at: true },
         where: whereInput,
         skip,
         take,
@@ -45,8 +67,8 @@ export class PersonalitiesService {
     /**
      * mapping
      */
-    const data = personalities.map((el): Personality.GetByPageData => {
-      return { id: el.id, keyword: el.keyword };
+    const data = personalities.map((el): Personality.GetResponse => {
+      return { id: el.id, keyword: el.keyword, createdAt: el.created_at.toISOString() };
     });
 
     return PaginationUtil.createResponse({


### PR DESCRIPTION
## 성격 전체 조회 API 추가

### 📌 관련 이슈


### ✏️ 변경 사항

1. `Get /personalities/all` 추가
- 성격을 페이지네이션 없이 전체 조회합니다.
- 조회 시 keyword 오름차순으로 나타나도록 정렬 조건 넣었습니다.