### PR TITLE
[Feat] update character

### DIFF
--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -1,5 +1,5 @@
 import core from '@nestia/core';
-import { Controller, UseGuards } from '@nestjs/common';
+import { Body, Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
@@ -52,5 +52,20 @@ export class CharactersController {
   @core.TypedRoute.Get(':id')
   async getCharacter(@core.TypedParam('id') id: Character['id']) {
     return await this.charactersService.get(id);
+  }
+
+  /**
+   * 캐릭터를 수정한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Patch(':id')
+  async updateCharacter(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('id') id: Character['id'],
+    @core.TypedBody() body: Character.UpdateRequest,
+  ) {
+    return await this.charactersService.update(member.id, id, body);
   }
 }

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -52,7 +52,7 @@ export class CharactersController {
    */
   @core.TypedRoute.Get(':id')
   async getCharacter(@core.TypedParam('id') id: Character['id']) {
-    return await this.charactersService.get(id);
+    return await this.charactersService.get(id, { isPublic: true });
   }
 
   /**

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -1,5 +1,5 @@
 import core from '@nestia/core';
-import { Body, Controller, UseGuards } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
@@ -67,7 +67,9 @@ export class CharactersController {
     @core.TypedParam('id') id: Character['id'],
     @core.TypedBody() body: Character.UpdateRequest,
   ): Promise<Common.Response> {
-    await this.charactersService.update(member.id, id, body);
-    return { message: '캐릭터가 수정되었습니다.' };
+    const changedInfo = await this.charactersService.update(member.id, id, body);
+    return changedInfo.length
+      ? { message: `캐릭터의 ${changedInfo.join(',')}(이)가 수정되었습니다.` }
+      : { message: `수정 사항이 없습니다.` };
   }
 }

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -66,10 +66,7 @@ export class CharactersController {
     @Member() member: Guard.MemberResponse,
     @core.TypedParam('id') id: Character['id'],
     @core.TypedBody() body: Character.UpdateRequest,
-  ): Promise<Common.Response> {
-    const changedInfo = await this.charactersService.update(member.id, id, body);
-    return changedInfo.length
-      ? { message: `캐릭터의 ${changedInfo.join(',')}(이)가 수정되었습니다.` }
-      : { message: `수정 사항이 없습니다.` };
+  ): Promise<Character.UpdateResponse> {
+    return await this.charactersService.update(member.id, id, body);
   }
 }

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -6,12 +6,15 @@ import { MemberGuard } from 'src/guards/member.guard';
 import { Character } from 'src/interfaces/characters.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { CharactersService } from 'src/services/characters.service';
-import { tags } from 'typia';
+import { ExperiencesService } from 'src/services/experiences.service';
 
 @ApiTags('Character')
 @Controller('characters')
 export class CharactersController {
-  constructor(private readonly charactersService: CharactersService) {}
+  constructor(
+    private readonly charactersService: CharactersService,
+    private readonly experiencesService: ExperiencesService,
+  ) {}
 
   /**
    * 캐릭터를 생성한다.
@@ -36,10 +39,18 @@ export class CharactersController {
   }
 
   /**
+   * 캐릭터의 경력들을 조회한다.
+   */
+  @core.TypedRoute.Get(':id/experiences')
+  async getCharacterExperiences(@core.TypedParam('id') id: Character['id']) {
+    return await this.experiencesService.getAllByCharacterId(id);
+  }
+
+  /**
    * 아이디로 캐릭터를 조회한다.
    */
   @core.TypedRoute.Get(':id')
-  async getCharacter(@core.TypedParam('id') id: string & tags.Format<'uuid'>) {
+  async getCharacter(@core.TypedParam('id') id: Character['id']) {
     return await this.charactersService.get(id);
   }
 }

--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -4,6 +4,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
 import { Character } from 'src/interfaces/characters.interface';
+import { Common } from 'src/interfaces/common.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { CharactersService } from 'src/services/characters.service';
 import { ExperiencesService } from 'src/services/experiences.service';
@@ -65,7 +66,8 @@ export class CharactersController {
     @Member() member: Guard.MemberResponse,
     @core.TypedParam('id') id: Character['id'],
     @core.TypedBody() body: Character.UpdateRequest,
-  ) {
-    return await this.charactersService.update(member.id, id, body);
+  ): Promise<Common.Response> {
+    await this.charactersService.update(member.id, id, body);
+    return { message: '캐릭터가 수정되었습니다.' };
   }
 }

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -3,6 +3,7 @@ import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
+import { Common } from 'src/interfaces/common.interface';
 import { Experience } from 'src/interfaces/experiences.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { ExperiencesService } from '../services/experiences.service';
@@ -62,8 +63,9 @@ export class ExperiencesController {
     @Member() member: Guard.MemberResponse,
     @core.TypedParam('id') id: Experience['id'],
     @core.TypedBody() body: Experience.UpdateRequest,
-  ): Promise<Experience.UpdateResponse> {
-    return await this.experiencesService.update(member.id, id, body);
+  ): Promise<Experience.GetResponse | Common.Response> {
+    const experience = await this.experiencesService.update(member.id, id, body);
+    return experience ?? { message: '수정된 내용이 없습니다.' };
   }
 
   /**
@@ -76,7 +78,8 @@ export class ExperiencesController {
   async deleteExperience(
     @Member() member: Guard.MemberResponse,
     @core.TypedParam('id') id: Experience['id'],
-  ): Promise<Experience.UpdateResponse> {
-    return await this.experiencesService.delete(member.id, id);
+  ): Promise<Common.Response> {
+    await this.experiencesService.delete(member.id, id);
+    return { message: '경력이 삭제되었습니다.' };
   }
 }

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -40,6 +40,19 @@ export class ExperiencesController {
   }
 
   /**
+   * 특정 경력을 사용하고 있는 캐릭터들을 반환한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get('/:id/characters')
+  async getCharacters(
+    @core.TypedParam('id') id: Experience['id'],
+  ): Promise<Array<Omit<Character, 'deletedAt' | 'memberId'>>> {
+    return await this.experiencesService.getCharacters(id);
+  }
+
+  /**
    * 경력을 조회한다.
    *
    * @security x-member bearer

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -3,6 +3,7 @@ import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Member } from 'src/decorators/member.decorator';
 import { MemberGuard } from 'src/guards/member.guard';
+import { Character } from 'src/interfaces/characters.interface';
 import { Common } from 'src/interfaces/common.interface';
 import { Experience } from 'src/interfaces/experiences.interface';
 import { Guard } from 'src/interfaces/guard.interface';
@@ -69,7 +70,8 @@ export class ExperiencesController {
   }
 
   /**
-   * 경력을 삭제한다.
+   * 경력을 삭제한다. 등록된 캐릭터가 있다면 이후 생성되는 채팅에 영향을 줍니다.
+   * 수정 이전의 채팅방의 경우 유지됩니다.
    *
    * @security x-member bearer
    */

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -32,6 +32,7 @@ export class SourcesController {
   /**
    * 캐릭터의 특정 소스를 수정한다. 변경된 내용이 있을때만 수정한다.
    *
+   * @deprecated
    * @security x-member bearer
    */
   @UseGuards(MemberGuard)
@@ -49,6 +50,7 @@ export class SourcesController {
   /**
    * 캐릭터의 특정 소스를 삭제한다. (soft-del)
    *
+   * @deprecated
    * @security x-member bearer
    */
   @UseGuards(MemberGuard)
@@ -64,7 +66,7 @@ export class SourcesController {
 
   /**
    * 소스 여러개를 저장한다.
-   *
+   * @deprecated
    * @security x-member bearer
    */
   @UseGuards(MemberGuard)
@@ -79,6 +81,7 @@ export class SourcesController {
   /**
    * 소스를 저장한다. 소스는 link, file 타입으로 나뉘며 자기소개서나, 이력서를 받을때 사용한다.
    *
+   * @deprecated
    * @security x-member bearer
    */
   @UseGuards(MemberGuard)
@@ -99,7 +102,7 @@ export class SourcesController {
   }
 
   /**
-   * 프로젝트에서 id 추출을 지원하는 노션 링크인지 검증한다. 지원하는 url 아니라면 exception -> false 값을 반환한다.
+   * 지원하는 노션 링크인지 검증한다.
    */
   @core.TypedRoute.Post('/notion/verify')
   async verifyNotionUrl(@core.TypedBody() body: Pick<Source, 'url'>): Promise<boolean> {
@@ -111,7 +114,7 @@ export class SourcesController {
   }
 
   /**
-   * 노션 링크를 받아 콘텐츠를 읽어 마크다운 문자열로 변환한다.
+   * 노션 콘텐츠를 마크다운 문자열로 변환한다.
    *
    * @security x-member bearer
    */

--- a/src/controllers/sources.controller.ts
+++ b/src/controllers/sources.controller.ts
@@ -19,34 +19,6 @@ export class SourcesController {
   ) {}
 
   /**
-   * 소스를 저장한다. 소스는 link, file 타입으로 나뉘며 자기소개서나, 이력서를 받을때 사용한다.
-   *
-   * @security x-member bearer
-   */
-  @UseGuards(MemberGuard)
-  @core.TypedRoute.Post('/:characterId')
-  async createSource(
-    @core.TypedParam('characterId') characterId: Source['characterId'],
-    @core.TypedBody() body: Source.CreateRequest,
-  ): Promise<Source.GetResponse> {
-    return await this.sourcesService.create(characterId, body);
-  }
-
-  /**
-   * 소스 여러개를 저장한다.
-   *
-   * @security x-member bearer
-   */
-  @UseGuards(MemberGuard)
-  @core.TypedRoute.Post('/bulk/:characterId')
-  async createSources(
-    @core.TypedParam('characterId') characterId: Source['characterId'],
-    @core.TypedBody() body: Array<Source.CreateRequest>,
-  ): Promise<Source.GetAllResponse> {
-    return await this.sourcesService.createMany(characterId, body);
-  }
-
-  /**
    * 캐릭터의 특정 소스를 조회한다.
    */
   @core.TypedRoute.Get('/:characterId/:id')
@@ -88,6 +60,34 @@ export class SourcesController {
   ): Promise<Common.Response> {
     await this.sourcesService.delete(member.id, characterId, id);
     return { message: '첨부 파일이 삭제되었습니다. ' };
+  }
+
+  /**
+   * 소스 여러개를 저장한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Post('/bulk/:characterId')
+  async createSources(
+    @core.TypedParam('characterId') characterId: Source['characterId'],
+    @core.TypedBody() body: Array<Source.CreateRequest>,
+  ): Promise<Source.GetAllResponse> {
+    return await this.sourcesService.createMany(characterId, body);
+  }
+
+  /**
+   * 소스를 저장한다. 소스는 link, file 타입으로 나뉘며 자기소개서나, 이력서를 받을때 사용한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Post('/:characterId')
+  async createSource(
+    @core.TypedParam('characterId') characterId: Source['characterId'],
+    @core.TypedBody() body: Source.CreateRequest,
+  ): Promise<Source.GetResponse> {
+    return await this.sourcesService.create(characterId, body);
   }
 
   /**

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -24,6 +24,11 @@ export namespace Character {
   export interface CreateSnapshotRequest extends Pick<Character, 'nickname'>, Partial<Pick<Character, 'image'>> {}
 
   /**
+   * 스냅샷 생성 응답 객체
+   */
+  export interface CreateSnapshotResponse extends Pick<Character, 'id' | 'nickname' | 'image' | 'createdAt'> {}
+
+  /**
    * 캐릭터 생성 요청 객체
    */
   export interface CreateRequest {

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -30,8 +30,7 @@ export namespace Character {
   /**
    * 캐릭터 생성 요청 객체
    */
-  export interface CreateRequest {
-    character: CharacterSnapshot.CreateRequest & Pick<Character, 'isPublic'>;
+  export interface CreateRequest extends Pick<Character, 'nickname' | 'isPublic'>, Partial<Pick<Character, 'image'>> {
     personalities: Array<Pick<Personality, 'id'>> & tags.MinItems<1>;
     experiences: Array<Pick<Experience, 'id'>> & tags.MinItems<1>;
     positions: Array<Position.CreateRequest> & tags.MinItems<1>;
@@ -47,8 +46,8 @@ export namespace Character {
   /**
    * 캐릭터 상세 조회 응답 객체
    */
-  export interface GetResponse {
-    character: Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'>;
+  export interface GetResponse
+    extends Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'> {
     personalities: Array<Pick<Personality, 'id' | 'keyword'>>;
     positions: Array<Pick<Position, 'id' | 'keyword'>>;
     skills: Array<Pick<Skill, 'id' | 'keyword'>>;
@@ -69,7 +68,17 @@ export namespace Character {
   export interface GetBypageData
     extends Pick<
       GetResponse,
-      'character' | 'personalities' | 'positions' | 'skills' | 'experienceYears' | 'roomCount'
+      | 'id'
+      | 'memberId'
+      | 'nickname'
+      | 'image'
+      | 'isPublic'
+      | 'createdAt'
+      | 'personalities'
+      | 'positions'
+      | 'skills'
+      | 'experienceYears'
+      | 'roomCount'
     > {}
 
   /**
@@ -88,7 +97,7 @@ export namespace CharacterSnapshot {
    * 스냅샷 생성 요청 객체
    */
   export interface CreateRequest
-    extends Pick<CharacterSnapshot, 'nickname'>,
+    extends Pick<CharacterSnapshot, 'characterId' | 'nickname' | 'createdAt'>,
       Partial<Pick<CharacterSnapshot, 'image'>> {}
 
   /**

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -10,29 +10,28 @@ import { Source } from './source.interface';
 export interface Character {
   id: string & tags.Format<'uuid'>;
   memberId: Member['id'];
+  nickname: CharacterSnapshot['nickname'];
+  image: CharacterSnapshot['image'];
+  isPublic: boolean;
+  createdAt: string & tags.Format<'date-time'>;
+  deletedAt: string & tags.Format<'date-time'>;
+}
+
+export interface CharacterSnapshot {
+  id: string & tags.Format<'uuid'>;
+  characterId: Character['id'];
   nickname: string & tags.MinLength<1>;
   image: (string & tags.MinLength<1>) | null;
-  isPublic: boolean;
   createdAt: string & tags.Format<'date-time'>;
   deletedAt: string & tags.Format<'date-time'>;
 }
 
 export namespace Character {
   /**
-   * 스냅샷 생성 요청 객체
-   */
-  export interface CreateSnapshotRequest extends Pick<Character, 'nickname'>, Partial<Pick<Character, 'image'>> {}
-
-  /**
-   * 스냅샷 생성 응답 객체
-   */
-  export interface CreateSnapshotResponse extends Pick<Character, 'id' | 'nickname' | 'image' | 'createdAt'> {}
-
-  /**
    * 캐릭터 생성 요청 객체
    */
   export interface CreateRequest {
-    character: Character.CreateSnapshotRequest & Pick<Character, 'isPublic'>;
+    character: CharacterSnapshot.CreateRequest & Pick<Character, 'isPublic'>;
     personalities: Array<Pick<Personality, 'id'>> & tags.MinItems<1>;
     experiences: Array<Pick<Experience, 'id'>> & tags.MinItems<1>;
     positions: Array<Position.CreateRequest> & tags.MinItems<1>;
@@ -82,4 +81,18 @@ export namespace Character {
    * 캐릭터 수정 요청 객체 (현재 생성 객체랑 동일)
    */
   export interface UpdateRequest extends CreateRequest {}
+}
+
+export namespace CharacterSnapshot {
+  /**
+   * 스냅샷 생성 요청 객체
+   */
+  export interface CreateRequest
+    extends Pick<CharacterSnapshot, 'nickname'>,
+      Partial<Pick<CharacterSnapshot, 'image'>> {}
+
+  /**
+   * 스냅샷 응답 객체
+   */
+  export interface GetResponse extends Pick<CharacterSnapshot, 'id' | 'nickname' | 'image' | 'createdAt'> {}
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -19,9 +19,15 @@ export interface Character {
 
 export namespace Character {
   /**
-   * create
+   * 스냅샷 생성 요청 객체
    */
-  export interface CreateRequest extends Pick<Character, 'nickname' | 'isPublic'>, Partial<Pick<Character, 'image'>> {
+  export interface CreateSnapshotRequest extends Pick<Character, 'nickname'>, Partial<Pick<Character, 'image'>> {}
+
+  /**
+   * 캐릭터 생성 요청 객체
+   */
+  export interface CreateRequest {
+    character: Character.CreateSnapshotRequest & Pick<Character, 'isPublic'>;
     personalities: Array<Pick<Personality, 'id'>> & tags.MinItems<1>;
     experiences: Array<Pick<Experience, 'id'>> & tags.MinItems<1>;
     positions: Array<Position.CreateRequest> & tags.MinItems<1>;
@@ -29,13 +35,16 @@ export namespace Character {
     sources: Array<Source.CreateRequest> & tags.MinItems<1>;
   }
 
+  /**
+   * 캐릭터 생성 응답 객체
+   */
   export interface CreateResponse extends Pick<Character, 'id'> {}
 
   /**
-   * get
+   * 캐릭터 상세 조회 응답 객체
    */
-  export interface GetResponse
-    extends Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'> {
+  export interface GetResponse {
+    character: Pick<Character, 'id' | 'memberId' | 'nickname' | 'image' | 'isPublic' | 'createdAt'>;
     personalities: Array<Pick<Personality, 'id' | 'keyword'>>;
     positions: Array<Pick<Position, 'id' | 'keyword'>>;
     skills: Array<Pick<Skill, 'id' | 'keyword'>>;
@@ -50,26 +59,22 @@ export namespace Character {
     search?: Character['nickname'] | Position['keyword'] | Skill['keyword'] | null;
   }
 
+  /**
+   * 캐릭터 페이지네이션 단일 객체
+   */
   export interface GetBypageData
     extends Pick<
       GetResponse,
-      | 'id'
-      | 'memberId'
-      | 'nickname'
-      | 'image'
-      | 'isPublic'
-      | 'createdAt'
-      | 'personalities'
-      | 'positions'
-      | 'skills'
-      | 'experienceYears'
-      | 'roomCount'
+      'character' | 'personalities' | 'positions' | 'skills' | 'experienceYears' | 'roomCount'
     > {}
 
+  /**
+   * 캐릭터 페이지네이션 전체 응답 객체
+   */
   export interface GetByPageResponse extends PaginationUtil.Response<Character.GetBypageData> {}
 
   /**
-   * update
+   * 캐릭터 수정 요청 객체 (현재 생성 객체랑 동일)
    */
-  export interface UpdateRequest extends Partial<Character.CreateRequest> {}
+  export interface UpdateRequest extends CreateRequest {}
 }

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -90,6 +90,19 @@ export namespace Character {
    * 캐릭터 수정 요청 객체 (현재 생성 객체랑 동일)
    */
   export interface UpdateRequest extends CreateRequest {}
+
+  /**
+   * 캐릭터 수정 응답 객체
+   */
+  export interface UpdateResponse {
+    isPublicChanged: boolean;
+    isPersonalitiesChanged: boolean;
+    isSourceChanged: boolean;
+    isSnapshotChanged: boolean;
+    isExperiencesChanged: boolean;
+    isPositionsChanged: boolean;
+    isSkillsChanged: boolean;
+  }
 }
 
 export namespace CharacterSnapshot {

--- a/src/interfaces/characters.interface.ts
+++ b/src/interfaces/characters.interface.ts
@@ -67,4 +67,9 @@ export namespace Character {
     > {}
 
   export interface GetByPageResponse extends PaginationUtil.Response<Character.GetBypageData> {}
+
+  /**
+   * update
+   */
+  export interface UpdateRequest extends Partial<Character.CreateRequest> {}
 }

--- a/src/interfaces/experiences.interface.ts
+++ b/src/interfaces/experiences.interface.ts
@@ -37,6 +37,4 @@ export namespace Experience {
    * update
    */
   export interface UpdateRequest extends Omit<CreateRequest, 'sequence'> {}
-
-  export interface UpdateResponse extends Pick<Experience, 'id'> {}
 }

--- a/src/modules/characters.module.ts
+++ b/src/modules/characters.module.ts
@@ -5,9 +5,10 @@ import { ExperiencesModule } from './experiences.module';
 import { PersonalitiesModule } from './personalities.module';
 import { PositionsModule } from './positions.module';
 import { SkillsModule } from './skills.module';
+import { SourcesModule } from './sources.module';
 
 @Module({
-  imports: [PersonalitiesModule, ExperiencesModule, PositionsModule, SkillsModule],
+  imports: [PersonalitiesModule, ExperiencesModule, PositionsModule, SkillsModule, SourcesModule],
   controllers: [CharactersController],
   providers: [CharactersService],
   exports: [CharactersService],

--- a/src/modules/characters.module.ts
+++ b/src/modules/characters.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CharactersService } from 'src/services/characters.service';
 import { CharactersController } from '../controllers/characters.controller';
+import { ExperiencesModule } from './experiences.module';
+import { PersonalitiesModule } from './personalities.module';
 import { PositionsModule } from './positions.module';
 import { SkillsModule } from './skills.module';
-import { ExperiencesModule } from './experiences.module';
 
 @Module({
-  imports: [ExperiencesModule, PositionsModule, SkillsModule],
+  imports: [PersonalitiesModule, ExperiencesModule, PositionsModule, SkillsModule],
   controllers: [CharactersController],
   providers: [CharactersService],
   exports: [CharactersService],

--- a/src/modules/sources.module.ts
+++ b/src/modules/sources.module.ts
@@ -6,6 +6,6 @@ import { SourcesService } from '../services/sources.service';
 @Module({
   controllers: [SourcesController],
   providers: [SourcesService, NotionService],
-  exports: [NotionService],
+  exports: [SourcesService, NotionService],
 })
 export class SourcesModule {}

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -18,6 +18,9 @@ export class CharactersService {
     private readonly skillsService: SkillsService,
   ) {}
 
+  /**
+   * 캐릭터를 생성한다.
+   */
   async create(memberId: string, input: Character.CreateRequest) {
     const characterId = randomUUID();
     const snapshotId = randomUUID();
@@ -101,6 +104,9 @@ export class CharactersService {
     return character;
   }
 
+  /**
+   * 특정 캐릭터를 조회한다.
+   */
   async get(id: string): Promise<Character.GetResponse> {
     const character = await this.prisma.character.findUnique({
       select: {
@@ -221,16 +227,11 @@ export class CharactersService {
   /**
    * 캐릭터를 페이지네이션 조회한다.
    *
-   * @param query 페이지네이션/정렬/검색 요청 쿼리이다.
-   * sort : 정렬조건, latest(최신순), roomCount(채팅방순)
-   * search : 검색조건, 캐릭터 닉네임, 직군, 기술명을 포함해 검색하도록 한다.
-   * position : 검색조건, 입력된 직군을 포함해 검색한다.
-   * skill : 검색조건, 입력된 기술명을 포함해 검색한다.
-   *
+   * @param query 페이지네이션 요청 쿼리 객체.
    * @param option 조회시 where 조건에 사용되는 옵셔널 파라미터의 객체이다.
-   * isPublic : 공개 여부이다. 공개된 캐릭터만 조회할 경우 true로 설정해야 한다,
-   * memberId : 특정 멤버의 캐릭터만 조회하고 싶다면, 이 파라미터에 아이디를 넣어주어야 한다.
-   * deletedAt : 삭제 여부이다. 삭제된 캐릭터도 조회하고 싶다면 true로 설정한다.
+   *    - isPublic : 공개 여부이다. 공개된 캐릭터만 조회할 경우 true로 설정해야 한다,
+   *    - memberId : 특정 멤버의 캐릭터만 조회하고 싶다면, 이 파라미터에 아이디를 넣어주어야 한다.
+   *    - deletedAt : 삭제 여부이다. 삭제된 캐릭터도 조회하고 싶다면 true로 설정한다.
    */
   async getBypage(
     query: Character.GetByPageRequest,
@@ -445,4 +446,9 @@ export class CharactersService {
       data: characterPersonalities,
     });
   }
+
+  /**
+   * 캐릭터를 수정한다.
+   */
+  async update(memberId: Member['id'], id: Character['id'], body: Character.UpdateRequest) {}
 }

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -38,7 +38,7 @@ export class CharactersService {
       data: {
         id: characterId,
         member_id: memberId,
-        is_public: input.isPublic,
+        is_public: input.character.isPublic,
         created_at: date,
         sources: {
           createMany: {
@@ -56,8 +56,8 @@ export class CharactersService {
         snapshots: {
           create: {
             id: snapshotId,
-            nickname: input.nickname,
-            image: input.image,
+            nickname: input.character.nickname,
+            image: input.character.image,
             created_at: date,
             /**
              * snapshot relations
@@ -180,10 +180,15 @@ export class CharactersService {
      * mapping
      */
     return {
-      id: character.id,
-      memberId: character.member_id,
-      isPublic: character.is_public,
-      createdAt: character.created_at.toISOString(),
+      character: {
+        id: character.id,
+        memberId: character.member_id,
+        isPublic: character.is_public,
+        createdAt: character.created_at.toISOString(),
+        nickname: snapshot.nickname,
+        image: snapshot.image,
+      },
+
       personalities: character.character_personalites.map((el) => {
         return { id: el.personality.id, keyword: el.personality.keyword };
       }),
@@ -200,8 +205,6 @@ export class CharactersService {
       /**
        * snapshot relation
        */
-      nickname: snapshot.nickname,
-      image: snapshot.image,
       positions: snapshot.character_snapshot_positions.map((el) => {
         return {
           id: el.postion.id,
@@ -387,10 +390,14 @@ export class CharactersService {
       const experienceYears = this.experiencesService.getExperienceYears(experiences);
 
       return {
-        id: el.id,
-        memberId: el.member_id,
-        isPublic: el.is_public,
-        createdAt: el.created_at.toISOString(),
+        character: {
+          id: el.id,
+          memberId: el.member_id,
+          isPublic: el.is_public,
+          createdAt: el.created_at.toISOString(),
+          nickname: snapshot.nickname,
+          image: snapshot.image,
+        },
         personalities: el.character_personalites.map((el) => {
           return { id: el.personality.id, keyword: el.personality.keyword };
         }),
@@ -398,8 +405,6 @@ export class CharactersService {
         /**
          * snapshot relation
          */
-        nickname: snapshot.nickname,
-        image: snapshot.image,
         positions: snapshot.character_snapshot_positions.map((el) => {
           return {
             id: el.postion.id,

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -78,9 +78,9 @@ export class CharactersService {
             },
             character_snapshot_positions: {
               createMany: {
-                data: positions.map((positionId) => {
+                data: positions.map((position) => {
                   return {
-                    position_id: positionId,
+                    position_id: position.id,
                   };
                 }),
               },
@@ -471,6 +471,9 @@ export class CharactersService {
       );
     }
 
+    // 직군(Position), 스킬(Skill) 생성
+    const positions = await this.positionsService.findOrCreateMany(newData.positions);
+
     await this.prisma.$transaction(async (tx) => {
       /**
        * 0. 캐릭터 공개 여부 수정
@@ -500,6 +503,11 @@ export class CharactersService {
        * 4. 경력-캐릭터 스냅샷 관계를 업데이트 한다.
        */
       await this.experiencesService.updateAndDeleteMany(tx, snapshotId, origin.experiences, newData.experiences, date);
+
+      /**
+       * 5. 직종-캐릭터 스냅샷 관계를 업데이트 한다.
+       */
+      await this.positionsService.updateAndDeleteMany(tx, snapshotId, origin.positions, positions);
     });
   }
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -11,6 +11,7 @@ import { PersonalitiesService } from './personalities.service';
 import { PositionsService } from './positions.service';
 import { PrismaService } from './prisma.service';
 import { SkillsService } from './skills.service';
+import { SourcesService } from './sources.service';
 
 @Injectable()
 export class CharactersService {
@@ -20,6 +21,7 @@ export class CharactersService {
     private readonly experiencesService: ExperiencesService,
     private readonly positionsService: PositionsService,
     private readonly skillsService: SkillsService,
+    private readonly sourcesService: SourcesService,
   ) {}
 
   /**
@@ -474,6 +476,7 @@ export class CharactersService {
     // 직군(Position), 스킬(Skill) 생성
     const positions = await this.positionsService.findOrCreateMany(newData.positions);
     const skills = await this.skillsService.findOrCreateMany(newData.skills);
+    const sources = await this.sourcesService.findOrCreateMany(id, newData.sources);
 
     await this.prisma.$transaction(async (tx) => {
       /**
@@ -489,29 +492,34 @@ export class CharactersService {
       await this.personalitiesService.updateAndDeleteMany(tx, id, origin.personalities, newData.personalities, date);
 
       /**
-       * 2. 캐릭터 기본 정보 업데이트
+       * 2. 첨부파일-캐릭터 관계를 업데이트 한다.
+       */
+      await this.sourcesService.deleteMany(tx, id, origin.sources, sources, date);
+
+      /**
+       * 3. 캐릭터 기본 정보 업데이트
        * 변경이 있다면 새로운 스냅샷을 생성하고 마지막 스냅샷을 업데이트 한다.
        */
       const newSnapshot = await this.createNewSnapshot(tx, id, origin.character, newData.character, date);
 
       /**
-       * 3. 하위에서 관계를 업데이트 하기위해 스냅샷 아이디를 저장한다.
+       * 4. 하위에서 관계를 업데이트 하기위해 스냅샷 아이디를 저장한다.
        * 앞서 새로 생성되지 않았다면, 가장 최근 스냅샷을 가져온다.
        */
       const snapshotId = newSnapshot?.id ?? (await this.getLastSnapshot(id, tx)).id;
 
       /**
-       * 4. 경력-캐릭터 스냅샷 관계를 업데이트 한다.
+       * 5. 경력-캐릭터 스냅샷 관계를 업데이트 한다.
        */
       await this.experiencesService.updateAndDeleteMany(tx, snapshotId, origin.experiences, newData.experiences, date);
 
       /**
-       * 5. 직종-캐릭터 스냅샷 관계를 업데이트 한다.
+       * 6. 직종-캐릭터 스냅샷 관계를 업데이트 한다.
        */
       await this.positionsService.updateAndDeleteMany(tx, snapshotId, origin.positions, positions);
 
       /**
-       * 6. 기술스택-캐릭터 스냅샷 관계를 업데이트 한다.
+       * 7. 기술스택-캐릭터 스냅샷 관계를 업데이트 한다.
        */
       await this.skillsService.updateAndDeleteMany(tx, snapshotId, origin.skills, skills);
     });

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -1,7 +1,8 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { Member, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Character, CharacterSnapshot } from 'src/interfaces/characters.interface';
+import { Member } from 'src/interfaces/member.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
 import { ObjectUtil } from 'src/util/object.util';
 import { PaginationUtil } from 'src/util/pagination.util';
@@ -487,6 +488,11 @@ export class CharactersService {
        * 앞서 새로 생성되지 않았다면, 가장 최근 스냅샷을 가져온다.
        */
       const snapshotId = newSnapshot?.id ?? (await this.getLastSnapshot(id, tx)).id;
+
+      /**
+       * 3. 경력-캐릭터 스냅샷 관계를 업데이트 한다.
+       */
+      await this.experiencesService.updateAndDeleteMany(tx, snapshotId, origin.experiences, newData.experiences, date);
     });
   }
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -470,6 +470,13 @@ export class CharactersService {
 
     await this.prisma.$transaction(async (tx) => {
       /**
+       * 0. 캐릭터 공개 여부 수정
+       */
+      if (origin.character.isPublic !== newData.character.isPublic) {
+        await tx.character.update({ data: { is_public: newData.character.isPublic }, where: { id: id } });
+      }
+
+      /**
        * 1. 캐릭터 기본 정보 업데이트
        * 변경이 있다면 새로운 스냅샷을 생성하고 마지막 스냅샷을 업데이트 한다.
        */

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -110,9 +110,20 @@ export class CharactersService {
   }
 
   /**
-   * 특정 캐릭터를 조회한다.
+   * 특정 캐릭터를 상세조회한다.
+   *
+   * @param id 조회할 캐릭터의 아이디
+   * @param option 조회 옵셔널 파라미터들이다.
+   * -  isPublic: 공개 캐릭터만 조회하고 싶을 경우 true로 설정한다.
    */
-  async get(id: string): Promise<Character.GetResponse> {
+  async get(
+    id: string,
+    option?: {
+      isPublic?: true;
+    },
+  ): Promise<Character.GetResponse> {
+    const whereInput: Prisma.CharacterWhereUniqueInput = { id: id, is_public: option?.isPublic ? true : undefined };
+
     const character = await this.prisma.character.findUnique({
       select: {
         id: true,
@@ -163,13 +174,13 @@ export class CharactersService {
         },
         _count: { select: { rooms: true } },
       },
-      where: { id, is_public: true },
+      where: whereInput,
     });
 
     const snapshot = character?.last_snapshot?.snapshot;
 
     if (!snapshot) {
-      throw new NotFoundException('캐릭터 조회 실패. 캐릭터 스냅샷이 존재하지 않습니다.');
+      throw new NotFoundException('캐릭터 조회 실패. 삭제되었거나 비공개 된 캐릭터 입니다.');
     }
 
     /**

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -498,7 +498,7 @@ export class CharactersService {
     /**
      * 변경점이 있을때만 스냅샷을 생성한다.
      */
-    if (ObjectUtil.isChanged(origin, newData)) {
+    if (ObjectUtil.isChanged(origin, newData, ['nickname', 'image'])) {
       const snapshotId = randomUUID();
       const newSnapshot = await tx.character_Snapshot.create({
         select: { id: true, nickname: true, image: true, created_at: true },

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -87,8 +87,8 @@ export class CharactersService {
             },
             character_snapshot_skills: {
               createMany: {
-                data: skills.map((skillId) => {
-                  return { skill_id: skillId };
+                data: skills.map((skill) => {
+                  return { skill_id: skill.id };
                 }),
               },
             },
@@ -473,6 +473,7 @@ export class CharactersService {
 
     // 직군(Position), 스킬(Skill) 생성
     const positions = await this.positionsService.findOrCreateMany(newData.positions);
+    const skills = await this.skillsService.findOrCreateMany(newData.skills);
 
     await this.prisma.$transaction(async (tx) => {
       /**
@@ -508,6 +509,11 @@ export class CharactersService {
        * 5. 직종-캐릭터 스냅샷 관계를 업데이트 한다.
        */
       await this.positionsService.updateAndDeleteMany(tx, snapshotId, origin.positions, positions);
+
+      /**
+       * 6. 기술스택-캐릭터 스냅샷 관계를 업데이트 한다.
+       */
+      await this.skillsService.updateAndDeleteMany(tx, snapshotId, origin.skills, skills);
     });
   }
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -165,7 +165,7 @@ export class CharactersService {
     const snapshot = character?.last_snapshot?.snapshot;
 
     if (!snapshot) {
-      throw new NotFoundException();
+      throw new NotFoundException('캐릭터 조회 실패. 캐릭터 스냅샷이 존재하지 않습니다.');
     }
 
     /**
@@ -382,7 +382,9 @@ export class CharactersService {
       const snapshot = el?.last_snapshot?.snapshot;
 
       if (!snapshot) {
-        throw new NotFoundException();
+        throw new NotFoundException(
+          `캐릭터 목록 조회 실패. 캐릭터 스냅샷 데이터가 존재하지않습니다. characterId: ${el.id}`,
+        );
       }
 
       const experiences = snapshot.character_snapshot_experiences.map((el) =>
@@ -461,7 +463,9 @@ export class CharactersService {
     const date = DateTimeUtil.now();
 
     if (origin.character.memberId !== memberId) {
-      throw new ForbiddenException('캐릭터 수정 권한이 없습니다. 본인의 캐릭터만 수정할 수 있습니다.');
+      throw new ForbiddenException(
+        '캐릭터 수정 실패. 캐릭터 수정 권한이 없습니다. 본인의 캐릭터만 수정할 수 있습니다.',
+      );
     }
 
     await this.prisma.$transaction(async (tx) => {
@@ -469,7 +473,7 @@ export class CharactersService {
        * 1. 캐릭터 기본 정보 업데이트
        * 변경이 있다면 새로운 스냅샷을 생성하고 마지막 스냅샷을 업데이트 한다.
        */
-      const newSnapshot = this.createNewSnapshot(tx, id, origin.character, newData.character, date);
+      const newSnapshot = await this.createNewSnapshot(tx, id, origin.character, newData.character, date);
     });
   }
 

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -165,7 +165,7 @@ export class CharactersService {
      * mapping experinece
      */
     const experiences = snapshot.character_snapshot_experiences.map((el) =>
-      this.experiencesService.mappingOutput(el.experience),
+      this.experiencesService.mapping(el.experience),
     );
 
     const experienceYears = this.experiencesService.getExperienceYears(experiences);
@@ -381,7 +381,7 @@ export class CharactersService {
       }
 
       const experiences = snapshot.character_snapshot_experiences.map((el) =>
-        this.experiencesService.mappingOutput(el.experience),
+        this.experiencesService.mapping(el.experience),
       );
       const experienceYears = this.experiencesService.getExperienceYears(experiences);
 

--- a/src/services/chats.service.ts
+++ b/src/services/chats.service.ts
@@ -139,7 +139,7 @@ export class ChatsService {
   }
 
   private async createSystemPrompt(userId: string, characterId: string, roomId: string): Promise<Chat.GetResponse> {
-    const character = await this.charactersService.get(characterId);
+    const character = await this.charactersService.get(characterId, { isPublic: true });
     const prompt = await this.promptsService.prompt(userId, character);
 
     const chat = await this.createSystemChat(roomId, { message: prompt });

--- a/src/services/experiences.service.ts
+++ b/src/services/experiences.service.ts
@@ -273,7 +273,13 @@ export class ExperiencesService {
     body: Experience.UpdateRequest,
   ): Promise<Experience.GetResponse | null> {
     const experience = await this.get(memberId, id);
-    const isChanged = ObjectUtil.isChanged(experience, body);
+    const isChanged = ObjectUtil.isChanged(experience, body, [
+      'companyName',
+      'description',
+      'position',
+      'startDate',
+      'endDate',
+    ]);
 
     if (!isChanged) {
       return null;

--- a/src/services/experiences.service.ts
+++ b/src/services/experiences.service.ts
@@ -2,12 +2,17 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { Experience } from 'src/interfaces/experiences.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
+import { ObjectUtil } from 'src/util/object.util';
 import { PrismaService } from './prisma.service';
 
 @Injectable()
 export class ExperiencesService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * experience에 대한 프리즈마 select where input을 반환합니다.
+   * 반복되는 스냅샷 select 문을 대체 할때 사용합니다.
+   */
   createSelectInput() {
     return {
       id: true,
@@ -29,6 +34,12 @@ export class ExperiencesService {
     } as const;
   }
 
+  /**
+   * createSelectInput()의 select 결과물을
+   * Experience.GetResponse 으로 조합합니다.
+   *
+   * @param experience
+   */
   mapping(experience: {
     id: string;
     created_at: Date;
@@ -46,7 +57,7 @@ export class ExperiencesService {
     const snapshot = experience.last_snapshot?.snapshot;
 
     if (!snapshot) {
-      throw new NotFoundException('경력 정보를 찾을 수 없습니다.');
+      throw new NotFoundException(`경력 인터페이스 매핑 실패 \n경력 스냅샷을 찾을 수 없습니다. id: ${experience.id}`);
     }
 
     return {
@@ -61,6 +72,9 @@ export class ExperiencesService {
     };
   }
 
+  /**
+   * 멤버의 경력 정보를 여러개 생성합니다. (트랜잭션 사용됨)
+   */
   async createMany(memberId: string, body: Experience.CreateManyRequest): Promise<Array<Experience.GetResponse>> {
     const { experiences } = body;
     const date = DateTimeUtil.now();
@@ -104,7 +118,8 @@ export class ExperiencesService {
   }
 
   /**
-   * 멤버가 저장한 경력을 조회한다. 삭제한 경력은 조회되지 않는다.
+   * 멤버가 저장한 경력들을 전체 조회한다. 삭제한 경력은 조회되지 않는다.
+   *
    * @param memberId 조회할 멤버의 아이디.
    */
   async getAll(memberId: string): Promise<Array<Experience.GetResponse>> {
@@ -119,6 +134,7 @@ export class ExperiencesService {
 
   /**
    * 캐릭터의 마지막 스냅샷에 저장된 경력들을 전체 조회합니다.
+   *
    * @param characterId 조회한 캐릭터의 아이디
    */
   async getAllByCharacterId(characterId: string): Promise<Array<Experience.GetResponse>> {
@@ -147,10 +163,14 @@ export class ExperiencesService {
     });
 
     const snapshot = character?.last_snapshot?.snapshot;
+
     if (!snapshot) {
-      throw new NotFoundException('캐릭터 정보를 찾을 수 없습니다.');
+      throw new NotFoundException(`캐릭터 스냅샷이 존재하지 않습니다. id: ${characterId}`);
     }
 
+    /**
+     * mapping
+     */
     return snapshot.character_snapshot_experiences.map((el) => this.mapping(el.experience));
   }
 
@@ -167,6 +187,9 @@ export class ExperiencesService {
     return totalYears;
   }
 
+  /**
+   * 멤버의 특정 경력을 조회한다.
+   */
   async get(memberId: string, id: Experience['id']): Promise<Experience.GetResponse> {
     const experience = await this.prisma.experience.findUnique({
       select: this.createSelectInput(),
@@ -174,28 +197,51 @@ export class ExperiencesService {
     });
 
     if (!experience) {
-      throw new NotFoundException();
+      throw new NotFoundException(`존재하지 않는 경력입니다.`);
     }
+    /**
+     * mapping
+     */
     return this.mapping(experience);
   }
 
+  /**
+   * 멤버의 경력을 수정합니다.
+   * 캐릭터 스냅샷관 연관 관계가 있을 경우 영향을 받습니다.
+   */
   async update(
     memberId: string,
     id: Experience['id'],
     body: Experience.UpdateRequest,
-  ): Promise<Experience.UpdateResponse> {
+  ): Promise<Experience.GetResponse | null> {
     const experience = await this.get(memberId, id);
+    const isChanged = ObjectUtil.isChanged(experience, body);
 
-    Object.keys(body).forEach(async (key) => {
-      if (experience[key] !== body[key]) {
-        await this.updateSnapshot(id, experience.sequence, body);
-      }
-    });
+    if (!isChanged) {
+      return null;
+    }
+    const newSnapshot = await this.updateSnapshot(id, experience.sequence, body);
 
-    return { id };
+    /**
+     * mapping
+     */
+    return {
+      id: experience.id,
+      createdAt: experience.createdAt,
+      companyName: newSnapshot.company_name,
+      position: newSnapshot.position,
+      description: newSnapshot.description,
+      startDate: newSnapshot.start_date,
+      endDate: newSnapshot.end_date,
+      sequence: newSnapshot.sequence,
+    };
   }
 
-  async delete(memberId: string, id: Experience['id']): Promise<Experience.UpdateResponse> {
+  /**
+   * 경력을 soft-del 처리합니다.
+   * 캐릭터 스냅샷에 영향주지 않습니다.
+   */
+  async delete(memberId: string, id: Experience['id']): Promise<void> {
     const experience = await this.get(memberId, id);
     const date = DateTimeUtil.now();
 
@@ -203,20 +249,16 @@ export class ExperiencesService {
       where: { id },
       data: { deleted_at: date },
     });
-
-    return { id };
   }
 
-  private async updateSnapshot(
-    id: Experience['id'],
-    sequence: Experience['sequence'],
-    body: Experience.UpdateRequest,
-  ): Promise<void> {
+  /**
+   * 특정 경력의 스냅샷을 새로 생성하고, last 스냅샷을 갱신합니다.
+   */
+  private async updateSnapshot(id: Experience['id'], sequence: Experience['sequence'], body: Experience.UpdateRequest) {
     const date = DateTimeUtil.now();
 
-    await this.prisma.$transaction(async (tx) => {
+    return await this.prisma.$transaction(async (tx) => {
       const newSnapshot = await tx.experience_Snapshot.create({
-        select: { id: true },
         data: {
           id: randomUUID(),
           experience_id: id,

--- a/src/services/personalities.service.ts
+++ b/src/services/personalities.service.ts
@@ -89,11 +89,11 @@ export class PersonalitiesService {
    *
    * @param tx 프리즈마 트랜잭션 객체
    * @param characterId 변경할 캐릭터의 아이디
-   * @param origin 기존 성격데이터들
+   * @param origin 기존 성격 데이터들
    * @param newData 새로운 성격 데이터들
    * @param createdAt 트랜잭션 시작 시점
    */
-  async updateAndDeleteMany(
+  async upsertAndDeleteMany(
     tx: Prisma.TransactionClient,
     characterId: Character['id'],
     origin: Array<Pick<Personality, 'id'>>,
@@ -108,8 +108,15 @@ export class PersonalitiesService {
     for (const [key, newItem] of newDataMap.entries()) {
       if (!originMap.has(key)) {
         // 기존 데이터에 해당 id(key)가 없으면, 새로 캐릭터와의 관계를 생성한다.
-        await tx.character_Personality.create({
-          data: { character_id: characterId, personality_id: newItem.id, created_at: createdAt },
+        await tx.character_Personality.upsert({
+          create: { character_id: characterId, personality_id: newItem.id, created_at: createdAt },
+          update: { created_at: createdAt, deleted_at: null },
+          where: {
+            character_id_personality_id: {
+              character_id: characterId,
+              personality_id: newItem.id,
+            },
+          },
         });
       }
     }

--- a/src/services/personalities.service.ts
+++ b/src/services/personalities.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
+import { Character } from 'src/interfaces/characters.interface';
 import { Personality } from 'src/interfaces/personalities.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
 import { PaginationUtil } from 'src/util/pagination.util';
@@ -80,5 +81,48 @@ export class PersonalitiesService {
       skip,
       take,
     });
+  }
+
+  /**
+   * 캐릭터의 성격 정보를 수정한다.
+   * 기존 데이터와 신규 데이터를 비교해 새로운 성격은 추가, 신규데이터에 없는 성격을 soft-del 처리한다.
+   *
+   * @param tx 프리즈마 트랜잭션 객체
+   * @param characterId 변경할 캐릭터의 아이디
+   * @param origin 기존 성격데이터들
+   * @param newData 새로운 성격 데이터들
+   * @param createdAt 트랜잭션 시작 시점
+   */
+  async updateAndDeleteMany(
+    tx: Prisma.TransactionClient,
+    characterId: Character['id'],
+    origin: Array<Pick<Personality, 'id'>>,
+    newData: Array<Pick<Personality, 'id'>>,
+    createdAt: string,
+  ): Promise<void> {
+    // 아이디를 key로 map을 생성한다.
+    const originMap = new Map(origin.map((el) => [el['id'], el]));
+    const newDataMap = new Map(newData.map((el) => [el['id'], el]));
+
+    // 1. 수정 처리
+    for (const [key, newItem] of newDataMap.entries()) {
+      if (!originMap.has(key)) {
+        // 기존 데이터에 해당 id(key)가 없으면, 새로 캐릭터와의 관계를 생성한다.
+        await tx.character_Personality.create({
+          data: { character_id: characterId, personality_id: newItem.id, created_at: createdAt },
+        });
+      }
+    }
+
+    // 2. 삭제 처리
+    for (const [key, originItem] of originMap.entries()) {
+      if (!newDataMap.has(key)) {
+        // 새로운 데이터 리스트에 없는 key는 삭제 처리한다.
+        await tx.character_Personality.updateMany({
+          where: { character_id: characterId, personality_id: originItem.id },
+          data: { deleted_at: createdAt },
+        });
+      }
+    }
   }
 }

--- a/src/services/positions.service.ts
+++ b/src/services/positions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
+import { CharacterSnapshot } from 'src/interfaces/characters.interface';
 import { Position } from 'src/interfaces/positions.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
 import { PaginationUtil } from 'src/util/pagination.util';
@@ -19,7 +20,7 @@ export class PositionsService {
     });
   }
 
-  async findOrCreateMany(body: Array<Position.CreateRequest>): Promise<Array<Position['id']>> {
+  async findOrCreateMany(body: Array<Position.CreateRequest>): Promise<Array<Pick<Position, 'id'>>> {
     const date = DateTimeUtil.now();
 
     return await Promise.all(
@@ -36,9 +37,9 @@ export class PositionsService {
             },
           });
 
-          return newPosition.id;
+          return { id: newPosition.id };
         }
-        return position.id;
+        return { id: position.id };
       }),
     );
   }
@@ -71,5 +72,45 @@ export class PositionsService {
     ]);
 
     return PaginationUtil.createResponse({ data, count, skip, take });
+  }
+
+  /**
+   * 캐릭터의 직종 정보를 수정한다.
+   * 기존의 데이터와 신규 데이터를 비교해, 새로운 경력은 추가하고 목록에 없는 직종은 삭제한다.
+   *
+   * @param tx 프리즈마 트랜잭션 클라이언트 객체
+   * @param characterSnapshotId 캐릭터 스냅샷 아이디
+   * @param origin 기존의 직종 데이터들
+   * @param newData 새로운 직종 데이터들
+   */
+  async updateAndDeleteMany(
+    tx: Prisma.TransactionClient,
+    characterSnapshotId: CharacterSnapshot['id'],
+    origin: Array<Pick<Position, 'id'>>,
+    newData: Array<Pick<Position, 'id'>>,
+  ) {
+    // 아이디를 key로
+    const originMap = new Map(origin.map((el) => [el['id'], el]));
+    const newDataMap = new Map(newData.map((el) => [el['id'], el]));
+
+    // 1. 수정 처리
+    for (const [key, newItem] of newDataMap.entries()) {
+      if (!originMap.has(key)) {
+        // 기존 데이터에 해당 id(key)가 없으면, 새로 스냅샷과의 관계를 생성한다.
+        await tx.character_Snapshot_Position.create({
+          data: { character_snapshot_id: characterSnapshotId, position_id: newItem.id },
+        });
+      }
+    }
+
+    // 2. 삭제 처리
+    for (const [key, originItem] of originMap.entries()) {
+      if (!newDataMap.has(key)) {
+        // 새로운 데이터 리스트에 없는 key는 삭제 처리
+        await tx.character_Snapshot_Position.deleteMany({
+          where: { character_snapshot_id: characterSnapshotId, position_id: originItem.id },
+        });
+      }
+    }
   }
 }

--- a/src/services/prisma.service.ts
+++ b/src/services/prisma.service.ts
@@ -6,4 +6,29 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
   }
+
+  /**
+   * 기존 조회 결과와 새로운 데이터를 비교해 변경점이 있는지 확인한다.
+   *
+   * @param origin 기존 데이터들의 id 객체 배열
+   * @param newData 신규 데이터들의 id 객체 배열
+   */
+  isChanged<T extends Record<'id', any>>(origin: Array<Pick<T, 'id'>>, newData: Array<Pick<T, 'id'>>): boolean {
+    const originIds = new Set(origin.map((el) => el.id));
+    const newIds = new Set(newData.map((el) => el.id));
+
+    for (const id of newIds) {
+      if (!originIds.has(id)) {
+        return true;
+      }
+    }
+
+    for (const id of originIds) {
+      if (!newIds.has(id)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/src/services/prompts.service.ts
+++ b/src/services/prompts.service.ts
@@ -23,7 +23,7 @@ export class PromptsService {
       this.formatKeywords(input.personalities),
       ``,
       `## 기본 정보`,
-      `- 이름: ${input.nickname}`,
+      `- 이름: ${input.character.nickname}`,
       `- 직무: ${this.formatKeywords(input.positions)}`,
       `- 사용 기술: ${this.formatKeywords(input.skills)}`,
       `- 경력: ${input.experienceYears}년`,

--- a/src/services/prompts.service.ts
+++ b/src/services/prompts.service.ts
@@ -23,7 +23,7 @@ export class PromptsService {
       this.formatKeywords(input.personalities),
       ``,
       `## 기본 정보`,
-      `- 이름: ${input.character.nickname}`,
+      `- 이름: ${input.nickname}`,
       `- 직무: ${this.formatKeywords(input.positions)}`,
       `- 사용 기술: ${this.formatKeywords(input.skills)}`,
       `- 경력: ${input.experienceYears}년`,

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -53,7 +53,7 @@ export class SourcesService {
             url: true,
             created_at: true,
           },
-          where: { character_id: characterId, type: el.type, url: el.url },
+          where: { character_id: characterId, type: el.type, url: el.url, deleted_at: null },
         });
 
         if (!source.length) {

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -109,7 +109,7 @@ export class SourcesService {
     body: Source.UpdateRequest,
   ): Promise<Source.GetResponse | null> {
     const source = await this.get(characterId, id, { memberId: memberId });
-    const isChanged = ObjectUtil.isChanged(source, body);
+    const isChanged = ObjectUtil.isChanged(source, body, ['type', 'subtype', 'url']);
 
     if (!isChanged) {
       return null;

--- a/src/services/sources.service.ts
+++ b/src/services/sources.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
+import { Character } from 'src/interfaces/characters.interface';
 import { Member } from 'src/interfaces/member.interface';
 import { Source } from 'src/interfaces/source.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
@@ -30,6 +31,49 @@ export class SourcesService {
     });
 
     return this.mapping(source);
+  }
+
+  /**
+   * 캐릭터의 소스를 조회 및 생성한다.
+   * type, url 정보가 같은 소스가 있는지 조회하고 없다면 새로 생성, 있다면 id를 반환한다.
+   */
+  async findOrCreateMany(
+    characterId: Character['id'],
+    body: Array<Source.CreateRequest>,
+  ): Promise<Array<Pick<Source, 'id'>>> {
+    const date = DateTimeUtil.now();
+
+    return await Promise.all(
+      body.map(async (el) => {
+        const source = await this.prisma.source.findMany({
+          select: {
+            id: true,
+            type: true,
+            subtype: true,
+            url: true,
+            created_at: true,
+          },
+          where: { character_id: characterId, type: el.type, url: el.url },
+        });
+
+        if (!source.length) {
+          const newSource = await this.prisma.source.create({
+            select: { id: true },
+            data: {
+              id: randomUUID(),
+              character_id: characterId,
+              type: el.type,
+              subtype: el.subtype,
+              url: el.url,
+              created_at: date,
+            },
+          });
+
+          return { id: newSource.id };
+        }
+        return { id: source.at(0)?.id as string };
+      }),
+    );
   }
 
   /**
@@ -154,6 +198,38 @@ export class SourcesService {
         deleted_at: date,
       },
     });
+  }
+
+  /**
+   * 캐릭터의 첨부파일을 삭제한다.
+   * 기존의 데이터와 신규 데이터를 비교해, 사라진 첨부파일을 삭제한다.
+   *
+   * @param tx 프리즈마 트랜잭션 클라이언트 객체
+   * @param characterId 수정하려는 캐릭터 아이디
+   * @param origin 기존의 첨부파일 데이터들
+   * @param newData 새로운 첨부파일 데이터들
+   * @param createdAt 트래잭션 시작 시점
+   */
+  async deleteMany(
+    tx: Prisma.TransactionClient,
+    characterId: Character['id'],
+    origin: Array<Pick<Source, 'id'>>,
+    newData: Array<Pick<Source, 'id'>>,
+    createdAt: string,
+  ) {
+    // 아이디를 key로 map 생성
+    const originMap = new Map(origin.map((el) => [el['id'], el]));
+    const newDataMap = new Map(newData.map((el) => [el['id'], el]));
+
+    // 삭제 처리
+    for (const [key, originItem] of originMap.entries()) {
+      if (!newDataMap.has(key)) {
+        await tx.source.updateMany({
+          where: { character_id: characterId, id: originItem.id },
+          data: { deleted_at: createdAt },
+        });
+      }
+    }
   }
 
   /**

--- a/src/util/object.util.ts
+++ b/src/util/object.util.ts
@@ -7,9 +7,17 @@ export namespace ObjectUtil {
   /**
    * original의 키를 기준으로 순회하며 updated에 다른 내용이 있는지 확인한다.
    * 변경된 내용이 있다면 true, 없다면 false를 반환한다.
+   *
+   * @param original T → 원본 객체
+   * @param updated Partial<T> → 수정된 객체 (일부 필드만 포함 가능)
+   * @param keys 비교할 키의 목록
    */
-  export function isChanged<T extends Record<string, any>>(original: T, updated: Partial<T>): boolean {
-    const changedFields = ObjectUtil.getChangedFields(original, updated);
+  export function isChanged<T extends Record<string, any>>(
+    original: T,
+    updated: Partial<T>,
+    keys: (keyof T)[] = [],
+  ): boolean {
+    const changedFields = getChangedFields(original, updated, keys);
     return isEmpty(changedFields) ? false : true;
   }
 
@@ -19,10 +27,15 @@ export namespace ObjectUtil {
    *
    * @param original T → 원본 객체
    * @param updated Partial<T> → 수정된 객체 (일부 필드만 포함 가능)
+   * @param keys 비교할 키의 목록
    */
-  export function getChangedFields<T extends Record<string, any>>(original: T, updated: Partial<T>): Partial<T> {
+  export function getChangedFields<T extends Record<string, any>>(
+    original: T,
+    updated: Partial<T>,
+    keys: (keyof T)[] = [],
+  ): Partial<T> {
     return Object.entries(updated).reduce((acc, [key, value]) => {
-      if (original[key] !== value) {
+      if (keys.includes(key as keyof T) && original[key] !== value) {
         acc[key as keyof T] = value;
       }
       return acc;


### PR DESCRIPTION
## 캐릭터 수정 API 추가

### 📌 관련 이슈

### ✏️ 변경 사항

1. `Patch /characters/:id`
- 캐릭터 수정 API가 추가되었습니다.
- 생성 API와 동일하게 body에 입력된 모든 정보를 보내주시면 됩니다.
- 백엔드에서 변경점을 확인해 자동으로 갱신*합니다.
- *요청에 새로 추가되는 정보는 신규로 생성, 요청에 없어진 정보는 삭제, 동일한 정보는 유지됩니다.
- 응답은 `boolean` 타입의 필드들로 구성된 객체이며, 변경 여부 대한 내용을 담습니다.
```ts
  export interface UpdateResponse {
    isPublicChanged: boolean; // 캐릭터의 공개 여부가 변경된 경우 true
    isPersonalitiesChanged: boolean; // 캐릭터의 성격정보가 변경된 경우 true
    isSourceChanged: boolean; // 캐릭터의 첨부파일 변경된 경우 true
    isSnapshotChanged: boolean; // 캐릭터의 스냅샷 정보(캐릭터 닉네임, 이미지)가 변경된 경우 true
    isExperiencesChanged: boolean; // 캐릭터의 경력 정보가 변경된 경우 true
    isPositionsChanged: boolean; // 캐릭터의 직군 정보가 변경된 경우 true
    isSkillsChanged: boolean; // 캐릭터의 스킬 정보가 변경된 경우 true
  }
```

2. 소스 API들 다수  deprecated 처리됨
- `Post /sources/:characterId`
- `Post /sources/bulk/:characterId`
- `Patch /sources/:characterId/:id`
- `Delete /sources/:characterId/:id`
- 캐릭터와의 관계 정합성을 위한 처리가 되어있지 않은 API들이라 deprecated 처리되었습니다.
- 소스 수정시 캐릭터 수정 API를 사용 부탁드립니다.


3. 기타
- `Get characters/:id/experiences` 캐릭터 경력 조회 API 추가됨
- `Get experiences/:id/characters` 특정 경력 사용하고 있는 캐릭터 목록 조회 API 추가됨
    - 경력 수정 시 사용자에게 영향을 받는 캐릭터 목록을 보여주면 어떨까 싶어 API로 구현해 두었습니다.
- 경력 수정 API 버그 수정 : 수정된 내용이 없을때도 스냅샷이 생성되는 버그 수정

