### PR TITLE
[Feat] Delete Character

### DIFF
--- a/src/controllers/characters.controller.ts
+++ b/src/controllers/characters.controller.ts
@@ -69,4 +69,21 @@ export class CharactersController {
   ): Promise<Character.UpdateResponse> {
     return await this.charactersService.update(member.id, id, body);
   }
+
+  /**
+   * 캐릭터를 삭제한다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Delete(':id')
+  async deleteCharacter(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('id') id: Character['id'],
+  ): Promise<Common.Response> {
+    await this.charactersService.delete(member.id, id);
+    return {
+      message: `캐릭터가 삭제되었습니다.`,
+    };
+  }
 }

--- a/src/services/characters.service.ts
+++ b/src/services/characters.service.ts
@@ -567,6 +567,38 @@ export class CharactersService {
   }
 
   /**
+   * 캐릭터를 삭제한다.
+   *
+   * @param memberId
+   * @param id
+   */
+  async delete(memberId: Member['id'], id: Character['id']): Promise<void> {
+    const character = await this.prisma.character.findUnique({
+      select: {
+        member_id: true,
+      },
+      where: {
+        id: id,
+      },
+    });
+
+    if (!character || character.member_id !== memberId) {
+      throw new NotFoundException(`캐릭터 삭제 실패. 이미 삭제된 캐릭터이거나 권한이 없습니다.`);
+    }
+
+    const date = DateTimeUtil.now();
+
+    await this.prisma.character.update({
+      data: {
+        deleted_at: date,
+      },
+      where: {
+        id: id,
+      },
+    });
+  }
+
+  /**
    * 캐릭터의 마지막 스냅샷을 조회한다.
    * @param characterId
    */


### PR DESCRIPTION
## 캐릭터 삭제 API 추가

### 📌 관련 이슈

### ✏️ 변경 사항

1. `Delete Characters/:id` 캐릭터 삭제 API 추가
- 캐릭터 삭제 API를 추가하였습니다.
- sofe-del 처리됩니다.
- 삭제후에는 `캐릭터 페이지네이션 조회 API (Get Characters/)`에서 더 이상 조회되지 않습니다. 
- `캐릭터 상세 조회 API (Get Characters/:id)` 에서는 삭제후에도 가능합니다.
