### PR TITLE
[Feat] get room status

### DIFF
--- a/src/controllers/rooms.controller.ts
+++ b/src/controllers/rooms.controller.ts
@@ -3,6 +3,7 @@ import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { User } from 'src/decorators/user.decorator';
 import { UserGuard } from 'src/guards/user.guard';
+import { Common } from 'src/interfaces/common.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { Room } from 'src/interfaces/rooms.interface';
 import { RoomsService } from 'src/services/rooms.service';
@@ -46,5 +47,20 @@ export class RoomsController {
   @core.TypedRoute.Get(':id')
   async getRoom(@User() user: Guard.UserResponse, @core.TypedParam('id') id: Room['id']): Promise<Room.GetResponse> {
     return this.roomsService.get(user.id, id);
+  }
+
+  /**
+   * 채팅방을 삭제한다.
+   *
+   * @security x-user bearer
+   */
+  @UseGuards(UserGuard)
+  @core.TypedRoute.Delete(':id')
+  async deleteRoom(@User() user: Guard.UserResponse, @core.TypedParam('id') id: Room['id']): Promise<Common.Response> {
+    await this.roomsService.delete(user.id, id);
+
+    return {
+      message: `채팅방이 삭제되었습니다.`,
+    };
   }
 }

--- a/src/interfaces/rooms.interface.ts
+++ b/src/interfaces/rooms.interface.ts
@@ -26,11 +26,16 @@ export namespace Room {
   export interface GetResponse extends Pick<Room, 'id' | 'createdAt'> {
     user: Pick<User, 'id'>;
     character: Pick<Character, 'id' | 'nickname' | 'image' | 'createdAt'>;
+    /**
+     * normal: 정상
+     * deleted : 캐릭터가 삭제됨
+     * changed: 캐릭터가 수정됨
+     * private: 캐릭터가 비공개됨
+     */
+    status: 'normal' | 'private' | 'changed' | 'deleted';
   }
 
   export interface GetByPageRequest extends PaginationUtil.Request {}
 
-  export interface GetByPageData extends Pick<Room, 'id' | 'userId' | 'characterId' | 'createdAt'> {}
-
-  export interface GetByPageResponse extends PaginationUtil.Response<Room.GetByPageData> {}
+  export interface GetByPageResponse extends PaginationUtil.Response<Room.GetResponse> {}
 }

--- a/src/services/rooms.service.ts
+++ b/src/services/rooms.service.ts
@@ -8,6 +8,7 @@ import { PaginationUtil } from 'src/util/pagination.util';
 import { AuthService } from './auth.service';
 import { PrismaService } from './prisma.service';
 import { User } from 'src/interfaces/user.interface';
+import { CharactersService } from './characters.service';
 
 @Injectable()
 export class RoomsService {
@@ -16,6 +17,9 @@ export class RoomsService {
     private readonly authService: AuthService,
   ) {}
 
+  /**
+   * 채팅방을 생성한다.
+   */
   async create(userId: string, body: Room.CreateRequest): Promise<Room.CreateResponse> {
     const date = DateTimeUtil.now();
 
@@ -32,6 +36,9 @@ export class RoomsService {
     return room;
   }
 
+  /**
+   * user의 채팅방 전체 목록을 가져온다.
+   */
   async getAll(userId: string): Promise<Array<Room.GetResponse>> {
     const userIds = await this.authService.findUserIds(userId);
 
@@ -60,7 +67,7 @@ export class RoomsService {
      */
     return rooms.map((el) => {
       if (!el || !el.character.last_snapshot) {
-        throw new NotFoundException();
+        throw new NotFoundException(`채팅방 전체 조회 실패.`);
       }
 
       return {
@@ -81,14 +88,12 @@ export class RoomsService {
 
   /**
    * 채팅방을 페이지네이션으로 조회한다.
-   * 
-   * @param query 페이지네이션 요청 객체이다.
-   * 
-   * @param option 조회 옵션에 관련된 옵셔널 파라미터들이 들어있다.
    *
-   * {characterId?: Character['id']} : 특정캐릭터의 데이터만을 조회하고 싶다면 id를 입력한다.
-
-   * {deletedAt?: true} : 삭제된 데이터를 포함해서 보고 싶다면 true로 설정한다.
+   * @param query 페이지네이션 요청 객체.
+   *
+   * @param option 조회 옵셔널 파라미터.
+   * - characterId: 특정캐릭터의 데이터만을 조회하고 싶다면 id를 입력한다.
+   * - deletedAt: 삭제된 데이터를 포함해서 보고 싶다면 true로 설정한다.
    */
   async getByPage(
     query: Room.GetByPageRequest,
@@ -127,6 +132,9 @@ export class RoomsService {
     });
   }
 
+  /**
+   * 채팅방을 상세 조회한다. 어떠한 캐릭터와 유저가 채팅방에 속해있는지 확인한다.
+   */
   async get(userId: string, id: string): Promise<Room.GetResponse> {
     const userIds = await this.authService.findUserIds(userId);
 
@@ -151,7 +159,7 @@ export class RoomsService {
     });
 
     if (!room || !room.character.last_snapshot) {
-      throw new NotFoundException();
+      throw new NotFoundException('채팅방 상세 조회 실패. 이미 삭제된 방이거나 데이터가 존재하지 않습니다.');
     }
 
     return {

--- a/src/services/rooms.service.ts
+++ b/src/services/rooms.service.ts
@@ -142,7 +142,7 @@ export class RoomsService {
       select: {
         user_id: true,
       },
-      where: { id },
+      where: { id: id, deleted_at: null },
     });
 
     if (!room || !userIds.includes(room.user_id)) {


### PR DESCRIPTION
## 채팅방 상태 관련 필드를 추가합니다.


### 📌 관련 이슈


### ✏️ 변경 사항
 
**1. 채팅방 상태 필드 추가**
- 다음 채팅방 관련 API에 캐릭터의 상태 여부를 나타내는 status 필드가 추가되었습니다.
- `Get /rooms` user 채팅방 전체 조회 API
- `Get /rooms/:id` user 채팅방 상세 조회 API
- `Get admin/rooms` admin 채팅방 전체 조회 API
- `Get admin/characters/:characterId/rooms` admin 특정 캐릭터 채팅방 조회

```ts
  export interface GetResponse extends Pick<Room, 'id' | 'createdAt'> {
    user: Pick<User, 'id'>;
    character: Pick<Character, 'id' | 'nickname' | 'image' | 'createdAt'>;
    /**
     * normal: 정상
     * deleted : 캐릭터가 삭제됨
     * changed: 캐릭터가 수정됨
     * private: 캐릭터가 비공개됨
     */
    status: 'normal' | 'private' | 'changed' | 'deleted';
  }
```
- 인터페이스는 위와 같습니다. 
- 상태는 `'normal' | 'private' | 'changed' | 'deleted'` 문자열로 노출됩니다.
 

**2. `Delete /rooms/;id`채팅방 삭제 API 추가**
- 채팅방 삭제 기능이 추가되었습니다.
- 삭제된 채팅방은 조회 API에서 더이상 조회되지 않습니다.