### PR TITLE
[Feat] Notion Verify

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { User } from 'src/decorators/user.decorator';
 import { UserGuard } from 'src/guards/user.guard';
 import { Auth } from 'src/interfaces/auth.interface';
+import { Common } from 'src/interfaces/common.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { AuthService } from 'src/services/auth.service';
 import { NotionUtil } from 'src/util/notion.util';
@@ -62,8 +63,11 @@ export class AuthController {
   async getNotionAuthorization(
     @User() user: Guard.UserResponse,
     @core.TypedQuery() query: Auth.LoginRequest,
-  ): Promise<void> {
-    return this.authService.getNotionAuthorization(user.id, query);
+  ): Promise<Common.Response> {
+    await this.authService.getNotionAuthorization(user.id, query);
+    return {
+      message: `노션 연동이 완료되었습니다.`,
+    };
   }
 
   /**

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import { UserGuard } from 'src/guards/user.guard';
 import { Auth } from 'src/interfaces/auth.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { AuthService } from 'src/services/auth.service';
+import { NotionUtil } from 'src/util/notion.util';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -66,18 +67,18 @@ export class AuthController {
   }
 
   /**
-   * 노션 API 연동 여부를 확인한다.
+   * 노션 API 연동 여부를 확인 후 연동 페이지 정보를 반환한다. 연동되지 않았거나, 연동된 페이지가 없다면 null을 반환.
    *
    * @security x-user bearer
    */
   @UseGuards(UserGuard)
   @core.TypedRoute.Get('notion/verify')
-  async notionVerify(@User() user: Guard.UserResponse): Promise<boolean> {
+  async notionVerify(@User() user: Guard.UserResponse): Promise<Array<NotionUtil.VerifyPageResponse> | null> {
     try {
-      await this.authService.getNotionAccessTokenByUserId(user.id);
-      return true;
+      const { password } = await this.authService.getNotionAccessTokenByUserId(user.id);
+      return await this.authService.getNotionAccessPages(password);
     } catch (err) {
-      return false;
+      return null;
     }
   }
 

--- a/src/util/notion.util.ts
+++ b/src/util/notion.util.ts
@@ -30,6 +30,14 @@ export namespace NotionUtil {
   }
 
   /**
+   * 노션 연동 페이지 목록 응답값
+   */
+  export interface VerifyPageResponse {
+    id: string;
+    title: string;
+    url: string;
+  }
+  /**
    * 노션 프라이빗 페이지 아이디 추출 정규식
    */
   export const privateNotionIdRegex = /https?:\/\/(www\.)?notion\.so\/(?:[^/]+\/)?[^\s/]*?([a-f0-9]{32})(?:\?[^\s]*)?$/;


### PR DESCRIPTION
## 노션 연동 검증 응답값 확장

### 📌 관련 이슈


### ✏️ 변경 사항

1. `Post /auth/notion/verify` 노션 연동 검증 API 응답값 확장
- 기존 : `boolean`
- 신규: `{ id: string;  title: string;  url: string; }[] | null`
- 연동된 페이지 정보가 나오도록 필드를 추가했습니다.
- 연동 정보가 없거나, 허가한 페이지가 없다면 null로 노출됩니다.