### PR TITLE
[Feat] Add Linked-In OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_REDIRECT_URI=
 
+# Linkedin OAuth
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+LINKEDIN_REDIRECT_URI=
+
 # Prisma Connection 
 DATABASE_URL="postgres://계정이름:비밀번호@localhost:포트/resupath"
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -54,7 +54,7 @@ export class AuthController {
   }
 
   /**
-   * 노션 AccessToken을 발급 받아 저장한다.
+   * 노션 AccessToken을 발급 받아 저장한다. 이후 노션 페이지 콘텐츠를 읽어오는데 사용한다.
    *
    * @security x-user bearer
    */
@@ -95,7 +95,7 @@ export class AuthController {
   }
 
   /**
-   * 깃허브 AccessToken을 발급 받아 저장한다.
+   * 클라이언트에서 받은 코드를 이용해 깃허브 로그인 유저를 검증하고 jwt를 발급한다.
    *
    * @security x-user bearer
    */
@@ -117,7 +117,7 @@ export class AuthController {
   }
 
   /**
-   * 링크드인 AccessToken을 발급 받아 저장한다.
+   *  클라이언트에서 받은 코드를 이용해 링크드인 로그인 유저를 검증하고 jwt를 발급한다.
    *
    * @security x-user bearer
    */

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -116,6 +116,19 @@ export class AuthController {
     return this.authService.getGithubLoginUrl(query.redirectUri);
   }
 
+  /**
+   * 링크드인 AccessToken을 발급 받아 저장한다.
+   *
+   * @security x-user bearer
+   */
+  @UseGuards(UserGuard)
+  @core.TypedRoute.Get('linkedin/callback')
+  async getLinkedinAuthorization(
+    @User() user: Guard.UserResponse,
+    @core.TypedQuery() query: Auth.LoginRequest,
+  ): Promise<Auth.LoginResponse> {
+    return await this.authService.getLinkedinAuthorization(user.id, query);
+  }
 
   /**
    * 링크드인 Authorization url을 반환한다.

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -115,4 +115,13 @@ export class AuthController {
   async getGithubAuthorizationUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
     return this.authService.getGithubLoginUrl(query.redirectUri);
   }
+
+
+  /**
+   * 링크드인 Authorization url을 반환한다.
+   */
+  @core.TypedRoute.Get('linkedin')
+  async getLinkedinAuthorizationUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
+    return this.authService.getLinkedinLoginUrl(query.redirectUri);
+  }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -98,7 +98,7 @@ export class AuthService {
       });
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException('노션 연동에 실패했습니다.');
+      throw new UnauthorizedException('노션 로그인에 실패했습니다.');
     }
   }
 
@@ -195,7 +195,7 @@ export class AuthService {
       return this.login(member);
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException('깃허브 연동에 실패했습니다.');
+      throw new UnauthorizedException('깃허브 로그인에 실패했습니다.');
     }
   }
 
@@ -227,7 +227,7 @@ export class AuthService {
       return this.login(member);
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException('링크드인 연동에 실패했습니다.');
+      throw new UnauthorizedException('링크드인 로그인에 실패했습니다.');
     }
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -200,6 +200,14 @@ export class AuthService {
   }
 
   /**
+   * 링크드인 로그인 url을 반환한다.
+   */
+  async getLinkedinLoginUrl(redirectUri?: string) {
+    const linkedin = this.getLinkedinClient();
+    return `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${linkedin.clientId}&redirect_uri=${redirectUri ?? linkedin.redirectUri}&scope=w_member_social`;
+  }
+
+  /**
    * 프로바이더(OAuth 연동) 정보를 저장한다.
    */
   async createProvider(memberId: string, authorization: Auth.CommonAuthorizationResponse): Promise<void> {
@@ -568,6 +576,14 @@ export class AuthService {
       clientId: this.configService.get<string>('GITHUB_CLIENT_ID'),
       clientSecret: this.configService.get<string>('GITHUB_CLIENT_SECRET'),
       redirectUri: this.configService.get<string>('GITHUB_REDIRECT_URI'),
+    };
+  }
+
+  private getLinkedinClient() {
+    return {
+      clientId: this.configService.get<string>('LINKEDIN_CLIENT_ID'),
+      clientSecret: this.configService.get<string>('LINKEDIN_CLIENT_SECRET'),
+      redirectUri: this.configService.get<string>('LINKEDIN_REDIRECT_URI'),
     };
   }
 }


### PR DESCRIPTION
## 링크드인 OAuth 로그인을 구현합니다.

### 📌 관련 이슈


### ✏️ 변경 사항

**1. `Get /auth/linkedin` 링크드인 로그인 url 발급 API 추가**

**2. `Get /auth/linkedin/callback` 링크드인 로그인 & 회원가입 API 추가**
- 클라이언트로 code를 전달받아 인증을 거쳐 유저 정보를 받아옵니다.
- 이미 가입된 사용자라면 로그인, 아니라면 회원가입 처리됩니다.
- @bkdragon0228  리다이렉트 url은 `https://resupath-front.vercel.app/linkedin/success`로 넣어두었습니다. 