### PR TITLE
[Feat] Add File Upload Exception

### DIFF
--- a/src/services/files.service.ts
+++ b/src/services/files.service.ts
@@ -1,6 +1,6 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { Files } from 'src/interfaces/files.interface';
@@ -25,6 +25,11 @@ export class S3Service {
    */
   async uploadFile(memberId: string, body: Files.CreateRequest): Promise<string> {
     const { file } = body;
+    const MAX_SIZE = 10 * 1024 * 1024; // 10MB
+
+    if (file.size > MAX_SIZE) {
+      throw new BadRequestException('파일 크기가 10MB를 초과했습니다.');
+    }
 
     const bucketName = this.getBucket();
     const regionName = this.getRegion();


### PR DESCRIPTION
## s3 파일 업로드 시 크기 제한 로직 추가

### 📌 관련 이슈


### ✏️ 변경 사항

1. `Post /files/upload` 서버 사이드 파일 업로드 API Exception 추가
- 파일 크기가 10MB를 넘는다면 `BadRequestException(400)`을 던지도록 수정했습니다.
- 과도한 s3 업로딩을 막기 위함이며, 10MB의 기준은 [사람인](https://www.saramin.co.kr)을 참고했습니다.
