### PR TITLE
[Feat] Add OAuth Link

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -6,13 +6,18 @@ import { UserGuard } from 'src/guards/user.guard';
 import { Auth } from 'src/interfaces/auth.interface';
 import { Common } from 'src/interfaces/common.interface';
 import { Guard } from 'src/interfaces/guard.interface';
+import { Provider } from 'src/interfaces/provider.interface';
 import { AuthService } from 'src/services/auth.service';
+import { OAuthService } from 'src/services/oauth.service';
 import { NotionUtil } from 'src/util/notion.util';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly oauthService: OAuthService,
+  ) {}
 
   /**
    * user를 생성하고 토큰을 발급한다.
@@ -37,37 +42,24 @@ export class AuthController {
    * @security x-user bearer
    */
   @UseGuards(UserGuard)
-  @core.TypedRoute.Get('google/callback')
+  @core.TypedRoute.Get('/:provider/callback')
   async getGoogleAuthorization(
     @User() user: Guard.UserResponse,
+    @core.TypedParam('provider') provider: Provider['type'],
     @core.TypedQuery() query: Auth.LoginRequest,
   ): Promise<Auth.LoginResponse> {
-    return this.authService.getGoogleAuthorization(user.id, query);
+    return this.authService.getAuthorization(provider, user.id, query);
   }
 
   /**
    * 클라이언트 요청에 따라 구글 로그인 url을 반환한다.
    */
-  @core.TypedRoute.Get('google')
-  async getGoogleLoginUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
-    return await this.authService.getGoogleLoginUrl(query.redirectUri);
-  }
-
-  /**
-   * 노션 AccessToken을 발급 받아 저장한다. 이후 노션 페이지 콘텐츠를 읽어오는데 사용한다.
-   *
-   * @security x-user bearer
-   */
-  @UseGuards(UserGuard)
-  @core.TypedRoute.Get('notion/callback')
-  async getNotionAuthorization(
-    @User() user: Guard.UserResponse,
-    @core.TypedQuery() query: Auth.LoginRequest,
-  ): Promise<Common.Response> {
-    await this.authService.getNotionAuthorization(user.id, query);
-    return {
-      message: `노션 연동이 완료되었습니다.`,
-    };
+  @core.TypedRoute.Get('/:provider')
+  async getGoogleLoginUrl(
+    @core.TypedParam('provider') provider: Provider['type'],
+    @core.TypedQuery() query: Auth.GetUrlRequest,
+  ): Promise<string> {
+    return await this.authService.getLoginUrl(provider, query.redirectUri);
   }
 
   /**
@@ -80,61 +72,9 @@ export class AuthController {
   async notionVerify(@User() user: Guard.UserResponse): Promise<Array<NotionUtil.VerifyPageResponse> | null> {
     try {
       const { password } = await this.authService.getNotionAccessTokenByUserId(user.id);
-      return await this.authService.getNotionAccessPages(password);
+      return await this.oauthService.getNotionAccessPages(password);
     } catch (err) {
       return null;
     }
-  }
-
-  /**
-   * 노션 Authorization url을 반환한다.
-   */
-  @core.TypedRoute.Get('notion')
-  async getNotionAuthorizationUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
-    return this.authService.getNotionLoginUrl(query.redirectUri);
-  }
-
-  /**
-   * 클라이언트에서 받은 코드를 이용해 깃허브 로그인 유저를 검증하고 jwt를 발급한다.
-   *
-   * @security x-user bearer
-   */
-  @UseGuards(UserGuard)
-  @core.TypedRoute.Get('github/callback')
-  async getGithubAuthorization(
-    @User() user: Guard.UserResponse,
-    @core.TypedQuery() query: Auth.LoginRequest,
-  ): Promise<Auth.LoginResponse> {
-    return this.authService.getGithubAuthorization(user.id, query);
-  }
-
-  /**
-   * 깃허브 Authorization url을 반환한다.
-   */
-  @core.TypedRoute.Get('github')
-  async getGithubAuthorizationUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
-    return this.authService.getGithubLoginUrl(query.redirectUri);
-  }
-
-  /**
-   *  클라이언트에서 받은 코드를 이용해 링크드인 로그인 유저를 검증하고 jwt를 발급한다.
-   *
-   * @security x-user bearer
-   */
-  @UseGuards(UserGuard)
-  @core.TypedRoute.Get('linkedin/callback')
-  async getLinkedinAuthorization(
-    @User() user: Guard.UserResponse,
-    @core.TypedQuery() query: Auth.LoginRequest,
-  ): Promise<Auth.LoginResponse> {
-    return await this.authService.getLinkedinAuthorization(user.id, query);
-  }
-
-  /**
-   * 링크드인 Authorization url을 반환한다.
-   */
-  @core.TypedRoute.Get('linkedin')
-  async getLinkedinAuthorizationUrl(@core.TypedQuery() query: Auth.GetUrlRequest): Promise<string> {
-    return this.authService.getLinkedinLoginUrl(query.redirectUri);
   }
 }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -42,6 +42,22 @@ export class AuthController {
    * @security x-user bearer
    */
   @UseGuards(UserGuard)
+  @core.TypedRoute.Get('/:provider/link')
+  async getAuthorizationLink(
+    @User() user: Guard.UserResponse,
+    @core.TypedParam('provider') provider: Provider['type'],
+    @core.TypedQuery() query: Auth.LoginRequest,
+  ): Promise<Common.Response> {
+    await this.authService.getAuthorizationLink(provider, user.id, query);
+    return { message: `${provider} 연동이 완료되었습니다.` };
+  }
+
+  /**
+   * 클라이언트에서 받은 코드를 이용해 구글 로그인 유저를 검증하고 jwt를 발급한다.
+   *
+   * @security x-user bearer
+   */
+  @UseGuards(UserGuard)
   @core.TypedRoute.Get('/:provider/callback')
   async getGoogleAuthorization(
     @User() user: Guard.UserResponse,

--- a/src/modules/auth.module.ts
+++ b/src/modules/auth.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { AuthController } from 'src/controllers/auth.controller';
 import { AuthService } from 'src/services/auth.service';
+import { OAuthService } from 'src/services/oauth.service';
 
 @Global()
 @Module({
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, OAuthService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -81,6 +81,32 @@ export class AuthService {
   }
 
   /**
+   * OAuth 로그인 연동을 처리한다.
+   * 다른 OAuth 인증으로 같은 member로 로그인하는 것이 가능하도록 한다.
+   */
+  async getAuthorizationLink(provider: Provider['type'], userId: string, input: Auth.LoginRequest) {
+    let userInfo: Auth.CommonAuthorizationResponse;
+    try {
+      if (provider === 'google') {
+        userInfo = await this.oAuthService.getGoogleAuthorization(input);
+      } else if (provider === 'notion') {
+        userInfo = await this.oAuthService.getNotionAuthorization(input);
+      } else if (provider === 'github') {
+        userInfo = await this.oAuthService.getGithubAuthorization(input);
+      } else if (provider === 'linkedin') {
+        userInfo = await this.oAuthService.getLinkedinAuthorization(input);
+      } else {
+        throw new BadRequestException(`지원하는 로그인이 아닙니다.`);
+      }
+      const { memberId } = await this.getMember(userId);
+      await this.createProvider(memberId, userInfo);
+    } catch (error) {
+      console.error(error);
+      throw new UnauthorizedException(`${provider} 연동에 실패했습니다. ${error.message}`);
+    }
+  }
+
+  /**
    * 해당 유저와 연관된 멤버에게 notion provider 조회결과가 있는지 확인한다.
    * @param userId
    */

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,13 +1,12 @@
-import { Injectable, InternalServerErrorException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import axios from 'axios';
 import { randomUUID } from 'crypto';
 import { Auth } from 'src/interfaces/auth.interface';
 import { Provider } from 'src/interfaces/provider.interface';
 import { User } from 'src/interfaces/user.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
-import { NotionUtil } from 'src/util/notion.util';
+import { OAuthService } from './oauth.service';
 import { PrismaService } from './prisma.service';
 
 @Injectable()
@@ -16,6 +15,7 @@ export class AuthService {
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly oAuthService: OAuthService,
   ) {}
 
   /**
@@ -39,66 +39,44 @@ export class AuthService {
   }
 
   /**
-   * 구글 로그인 페이지의 url을 반환한다.
+   * OAuth 로그인 url을 반환한다.
    */
-  async getGoogleLoginUrl(redirectUri?: string) {
-    const google = this.getGoogleClient();
-    const scope = encodeURIComponent('profile email'); // 허용된 스코프는 프로필과 이메일이다.
-
-    return `https://accounts.google.com/o/oauth2/v2/auth?client_id=${google.clientId}&redirect_uri=${redirectUri ?? google.redirectUri}&scope=${scope}&response_type=code&access_type=offline&prompt=consent`;
-  }
-
-  /**
-   * 구글 로그인 결과를 검증하고 jwt를 발급한다.
-   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
-   */
-  async getGoogleAuthorization(userId: string, input: Auth.LoginRequest) {
-    try {
-      const { accessToken, refreshToken } = await this.getGoogleAccessToken(input);
-      const { uid, name } = await this.getGoogleUserInfo(accessToken);
-
-      const member = await this.findOrCreateMember(userId, {
-        uid,
-        name,
-        accessToken,
-        refreshToken,
-        type: 'google',
-      });
-
-      return this.login(member);
-    } catch (error) {
-      console.error(error);
-      throw new UnauthorizedException('구글 로그인에 실패했습니다.');
+  async getLoginUrl(provider: Provider['type'], redirectUri?: string) {
+    if (provider === 'google') {
+      return await this.oAuthService.getGoogleLoginUrl(redirectUri);
+    } else if (provider === 'notion') {
+      return await this.oAuthService.getNotionLoginUrl(redirectUri);
+    } else if (provider === 'github') {
+      return await this.oAuthService.getGithubLoginUrl(redirectUri);
+    } else if (provider === 'linkedin') {
+      return await this.oAuthService.getLinkedinLoginUrl(redirectUri);
+    } else {
+      throw new BadRequestException(`지원하는 로그인이 아닙니다.`);
     }
   }
 
   /**
-   * 노션 로그인 페이지의 url을 반환한다.
+   * OAuth 사용자를 인증하고, 토큰을 발급한다.
+   * 새로운 사용자라면 회원가입을, 아니라면 로그인 처리된다.
    */
-  async getNotionLoginUrl(redirectUri?: string) {
-    const notion = this.getNotionClient();
-    return `https://api.notion.com/v1/oauth/authorize?client_id=${notion.clientId}&response_type=code&owner=user&redirect_uri=${redirectUri ?? notion.redirectUri}`;
-  }
-
-  /**
-   * 노션 인증 결과를 검증하고 jwt를 발급한다.
-   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
-   */
-  async getNotionAuthorization(userId: string, input: Auth.LoginRequest) {
+  async getAuthorization(provider: Provider['type'], userId: string, input: Auth.LoginRequest) {
+    let userInfo: Auth.CommonAuthorizationResponse;
     try {
-      const notion = await this.getNotionAccessTokenAndUserinfo(input);
-      const { memberId } = await this.getMember(userId);
+      if (provider === 'google') {
+        userInfo = await this.oAuthService.getGoogleAuthorization(input);
+      } else if (provider === 'github') {
+        userInfo = await this.oAuthService.getGithubAuthorization(input);
+      } else if (provider === 'linkedin') {
+        userInfo = await this.oAuthService.getLinkedinAuthorization(input);
+      } else {
+        throw new BadRequestException(`지원하는 로그인이 아닙니다.`);
+      }
 
-      await this.createProvider(memberId, {
-        uid: notion.owner.user.id,
-        name: notion.owner.user.name,
-        accessToken: notion.access_token,
-        refreshToken: notion.access_token, // 노션의 경우 access 토큰의 만료가 없음으로 access 토큰을 저장한다.
-        type: 'notion',
-      });
+      const member = await this.findOrCreateMember(userId, userInfo);
+      return this.login(member);
     } catch (error) {
       console.error(error);
-      throw new UnauthorizedException('노션 로그인에 실패했습니다.');
+      throw new UnauthorizedException(`${provider} 로그인에 실패했습니다. ${error.message}`);
     }
   }
 
@@ -128,107 +106,6 @@ export class AuthService {
     }
 
     return provider;
-  }
-
-  /**
-   * 허가된 노션 페이지를 조회한다.
-   */
-  async getNotionAccessPages(accessToken: string): Promise<Array<NotionUtil.VerifyPageResponse>> {
-    const { apiVersion } = this.getNotionClient();
-
-    try {
-      const response = await axios.post(
-        `https://api.notion.com/v1/search`,
-        {
-          filter: {
-            value: 'page',
-            property: 'object',
-          },
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Notion-Version': apiVersion,
-          },
-        },
-      );
-
-      const page = response.data.results;
-
-      return page.map(
-        (el): NotionUtil.VerifyPageResponse => ({
-          id: el.id,
-          title: el.properties.title.title[0].plain_text,
-          url: el.url,
-        }),
-      );
-    } catch (error) {
-      throw new InternalServerErrorException(`노션 페이지 정보 읽어오기 실패.`);
-    }
-  }
-
-  /**
-   * 깃허브 로그인 url을 반환한다.
-   */
-  async getGithubLoginUrl(redirectUri?: string) {
-    const github = this.getGithubClient();
-    return `https://github.com/login/oauth/authorize?client_id=${github.clientId}&redirect_uri=${redirectUri ?? github.redirectUri}&scope=user&prompt=select_account`;
-  }
-
-  /**
-   * 깃허브 인증 결과를 검증하고 jwt를 발급한다.
-   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
-   */
-  async getGithubAuthorization(userId: string, input: Auth.LoginRequest) {
-    try {
-      const { accessToken } = await this.getGithubAccessToken(input);
-      const { uid, name } = await this.getGithubUserInfo(accessToken);
-
-      const member = await this.findOrCreateMember(userId, {
-        uid,
-        name,
-        accessToken,
-        refreshToken: accessToken, // 깃허브 Oauth는 refresh token을 제공하지 않아 accessToken으로 저장한다.
-        type: 'github',
-      });
-
-      return this.login(member);
-    } catch (error) {
-      console.error(error);
-      throw new UnauthorizedException('깃허브 로그인에 실패했습니다.');
-    }
-  }
-
-  /**
-   * 링크드인 로그인 url을 반환한다.
-   */
-  async getLinkedinLoginUrl(redirectUri?: string) {
-    const linkedin = this.getLinkedinClient();
-    return `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${linkedin.clientId}&redirect_uri=${redirectUri ?? linkedin.redirectUri}&scope=openid%20profile%20email`;
-  }
-
-  /**
-   * 링크드인 인증 결과를 검증하고 jwt를 발급한다.
-   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
-   */
-  async getLinkedinAuthorization(userId: string, input: Auth.LoginRequest) {
-    try {
-      const { accessToken } = await this.getLinkedinAccessToken(input);
-      const { uid, name } = await this.getLinkedinUserInfo(accessToken);
-
-      const member = await this.findOrCreateMember(userId, {
-        uid,
-        name,
-        accessToken,
-        refreshToken: accessToken, // 링크드인 Oauth는 refresh token을 제공하지 않아 accessToken으로 저장한다.
-        type: 'linkedin',
-      });
-
-      return this.login(member);
-    } catch (error) {
-      console.error(error);
-      throw new UnauthorizedException('링크드인 로그인에 실패했습니다.');
-    }
   }
 
   /**
@@ -414,245 +291,5 @@ export class AuthService {
     });
 
     return { ...member, accessToken, refreshToken };
-  }
-
-  /**
-   * google
-   *
-   * code를 구글 OAuth 토큰으로 교환한다. 유저 정보를 받아오는데에 사용한다.
-   */
-  private async getGoogleAccessToken(input: Auth.LoginRequest) {
-    const { clientId, clientSecret, redirectUri } = this.getGoogleClient();
-
-    const response = await axios.post<{
-      access_token: string;
-      refresh_token: string;
-      token_type: 'Bearer';
-      scope: string;
-      expires_in: number;
-    }>(`https://oauth2.googleapis.com/token`, {
-      code: input.code,
-      client_id: clientId,
-      client_secret: clientSecret,
-      redirect_uri: input.redirectUri ?? redirectUri,
-      grant_type: 'authorization_code',
-    });
-
-    return {
-      accessToken: response.data.access_token,
-      refreshToken: response.data.refresh_token,
-    };
-  }
-
-  /**
-   * google
-   *
-   * access token을 사용해 구글 유저 정보를 조회한다.
-   */
-  private async getGoogleUserInfo(accessToken: string) {
-    const response = await axios.get<{
-      id: string;
-      email: string;
-      verified_email: boolean;
-      name: string;
-      given_name: string;
-      family_name: string;
-      picture: string;
-    }>('https://www.googleapis.com/oauth2/v2/userinfo', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    return {
-      uid: response.data.id,
-      name: response.data.name,
-    };
-  }
-
-  /**
-   * notion
-   *
-   * code를 이용해 인증후 노션 사용자 정보를 받아온다.
-   */
-  private async getNotionAccessTokenAndUserinfo(input: Auth.LoginRequest) {
-    const { clientId, clientSecret, redirectUri } = this.getNotionClient();
-
-    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
-
-    const response = await axios.post<NotionUtil.AuthorizationResponse>(
-      `https://api.notion.com/v1/oauth/token`,
-      {
-        grant_type: 'authorization_code',
-        code: input.code,
-        redirect_uri: input.redirectUri ?? redirectUri,
-      },
-      {
-        headers: {
-          Authorization: `Basic ${basicAuth}`,
-          'Content-Type': 'application/json',
-        },
-      },
-    );
-
-    return response.data;
-  }
-
-  /**
-   * github
-   *
-   * code를 이용해 깃허브 Access Token을 가져온다.
-   */
-  private async getGithubAccessToken(input: Auth.LoginRequest) {
-    const { clientId, clientSecret, redirectUri } = this.getGithubClient();
-
-    const response = await axios.post<{
-      access_token: string;
-      scope: string;
-      token_type: 'bearer';
-    }>(
-      `https://github.com/login/oauth/access_token`,
-      {
-        client_id: clientId,
-        client_secret: clientSecret,
-        code: input.code,
-        redirect_uri: input.redirectUri ?? redirectUri,
-      },
-      {
-        headers: {
-          Accept: 'application/json',
-        },
-      },
-    );
-
-    return { accessToken: response.data.access_token };
-  }
-
-  /**
-   * github
-   *
-   * 깃허브 유저 데이터를 가져온다.
-   */
-  private async getGithubUserInfo(accessToken: string) {
-    const response = await axios.get<{
-      login: string;
-      id: number;
-      node_id: string;
-      avatar_url: string;
-      gravatar_id: string;
-      url: string;
-      html_url: string;
-      followers_url: string;
-      following_url: string;
-      gists_url: string;
-      starred_url: string;
-      subscriptions_url: string;
-      organizations_url: string;
-      repos_url: string;
-      events_url: string;
-      received_events_url: string;
-      type: string;
-      user_view_type: string;
-      site_admin: boolean;
-      name: string;
-      company: string | null;
-      blog: string;
-      location: string | null;
-      email: string | null;
-      hireable: boolean | null;
-      bio: string | null;
-      twitter_username: string | null;
-      notification_email: string | null;
-      public_repos: number;
-      public_gists: number;
-      followers: number;
-      following: number;
-      created_at: string;
-      updated_at: string;
-    }>('https://api.github.com/user', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    return { uid: `${response.data.id}`, name: response.data.name };
-  }
-
-  /**
-   * Linked-In
-   *
-   * code를 링크드인 OAuth 토큰으로 교환한다. 유저 정보를 받아오는데에 사용한다.
-   */
-  private async getLinkedinAccessToken(input: Auth.LoginRequest) {
-    const { clientId, clientSecret, redirectUri } = this.getLinkedinClient();
-
-    const response = await axios.post<{ access_token: string; expires_in: number; scope: string }>(
-      `https://www.linkedin.com/oauth/v2/accessToken`,
-      {
-        grant_type: 'authorization_code',
-        code: input.code,
-        client_id: clientId,
-        client_secret: clientSecret,
-        redirect_uri: input.redirectUri ?? redirectUri,
-      },
-      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
-    );
-
-    return { accessToken: response.data.access_token };
-  }
-
-  /**
-   * Linked-In
-   *
-   * access token을 사용해 링크드인 유저 정보를 조회한다.
-   */
-  private async getLinkedinUserInfo(accessToken: string) {
-    const response = await axios.get<{
-      sub: string;
-      email_verified: boolean;
-      name: string;
-      locale: object;
-      given_name: string;
-      family_name: string;
-      email: string;
-    }>('https://api.linkedin.com/v2/userinfo', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    return { uid: response.data.sub, name: response.data.name };
-  }
-
-  private getGoogleClient() {
-    return {
-      clientId: this.configService.get<string>('GOOGLE_CLIENT_ID'),
-      clientSecret: this.configService.get<string>('GOOGLE_CLIENT_SECRET'),
-      redirectUri: this.configService.get<string>('GOOGLE_REDIRECT_URI'),
-    };
-  }
-
-  private getNotionClient() {
-    return {
-      clientId: this.configService.get<string>('NOTION_CLIENT_ID'),
-      clientSecret: this.configService.get<string>('NOTION_CLIENT_SECRET'),
-      redirectUri: this.configService.get<string>('NOTION_REDIRECT_URI'),
-      apiVersion: this.configService.get<string>('NOTION_API_VERSION'),
-    };
-  }
-
-  private getGithubClient() {
-    return {
-      clientId: this.configService.get<string>('GITHUB_CLIENT_ID'),
-      clientSecret: this.configService.get<string>('GITHUB_CLIENT_SECRET'),
-      redirectUri: this.configService.get<string>('GITHUB_REDIRECT_URI'),
-    };
-  }
-
-  private getLinkedinClient() {
-    return {
-      clientId: this.configService.get<string>('LINKEDIN_CLIENT_ID'),
-      clientSecret: this.configService.get<string>('LINKEDIN_CLIENT_SECRET'),
-      redirectUri: this.configService.get<string>('LINKEDIN_REDIRECT_URI'),
-    };
   }
 }

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -1,0 +1,380 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { Auth } from 'src/interfaces/auth.interface';
+import { NotionUtil } from 'src/util/notion.util';
+
+@Injectable()
+export class OAuthService {
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * 구글 로그인 페이지의 url을 반환한다.
+   */
+  async getGoogleLoginUrl(redirectUri?: string) {
+    const google = this.getGoogleClient();
+    const scope = encodeURIComponent('profile email'); // 허용된 스코프는 프로필과 이메일이다.
+
+    return `https://accounts.google.com/o/oauth2/v2/auth?client_id=${google.clientId}&redirect_uri=${redirectUri ?? google.redirectUri}&scope=${scope}&response_type=code&access_type=offline&prompt=consent`;
+  }
+
+  /**
+   * 노션 로그인 페이지의 url을 반환한다.
+   */
+  async getNotionLoginUrl(redirectUri?: string) {
+    const notion = this.getNotionClient();
+    return `https://api.notion.com/v1/oauth/authorize?client_id=${notion.clientId}&response_type=code&owner=user&redirect_uri=${redirectUri ?? notion.redirectUri}`;
+  }
+
+  /**
+   * 깃허브 로그인 url을 반환한다.
+   */
+  async getGithubLoginUrl(redirectUri?: string) {
+    const github = this.getGithubClient();
+    return `https://github.com/login/oauth/authorize?client_id=${github.clientId}&redirect_uri=${redirectUri ?? github.redirectUri}&scope=user&prompt=select_account`;
+  }
+
+  /**
+   * 링크드인 로그인 url을 반환한다.
+   */
+  async getLinkedinLoginUrl(redirectUri?: string) {
+    const linkedin = this.getLinkedinClient();
+    return `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${linkedin.clientId}&redirect_uri=${redirectUri ?? linkedin.redirectUri}&scope=openid%20profile%20email`;
+  }
+
+  /**
+   * 구글 로그인 결과를 검증하고 유저 데이터를 반환한다.
+   */
+  async getGoogleAuthorization(input: Auth.LoginRequest): Promise<Auth.CommonAuthorizationResponse> {
+    const { accessToken, refreshToken } = await this.getGoogleAccessToken(input);
+    const { uid, name } = await this.getGoogleUserInfo(accessToken);
+
+    return { uid, name, accessToken, refreshToken, type: 'google' };
+  }
+
+  /**
+   * 노션 인증 결과를 검증하고 유저 데이터를 반환한다.
+   */
+  async getNotionAuthorization(input: Auth.LoginRequest): Promise<Auth.CommonAuthorizationResponse> {
+    const notion = await this.getNotionAccessTokenAndUserinfo(input);
+
+    return {
+      uid: notion.owner.user.id,
+      name: notion.owner.user.name,
+      accessToken: notion.access_token,
+      refreshToken: notion.access_token, // 노션의 경우 access 토큰의 만료가 없음으로 access 토큰을 저장한다.
+      type: 'notion',
+    };
+  }
+
+  /**
+   * 깃허브 인증 결과를 검증하고 유저 정보를 반환한다.
+   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
+   */
+  async getGithubAuthorization(input: Auth.LoginRequest): Promise<Auth.CommonAuthorizationResponse> {
+    const { accessToken } = await this.getGithubAccessToken(input);
+    const { uid, name } = await this.getGithubUserInfo(accessToken);
+
+    return {
+      uid,
+      name,
+      accessToken,
+      refreshToken: accessToken, // 깃허브 Oauth는 refresh token을 제공하지 않아 accessToken으로 저장한다.
+      type: 'github',
+    };
+  }
+
+  /**
+   * 링크드인 인증 결과를 검증하고 jwt를 발급한다.
+   * @param code 클라이언트의 로그인 성공 시 얻을수 있는 코드값.
+   */
+  async getLinkedinAuthorization(input: Auth.LoginRequest): Promise<Auth.CommonAuthorizationResponse> {
+    const { accessToken } = await this.getLinkedinAccessToken(input);
+    const { uid, name } = await this.getLinkedinUserInfo(accessToken);
+
+    return {
+      uid,
+      name,
+      accessToken,
+      refreshToken: accessToken, // 링크드인 Oauth는 refresh token을 제공하지 않아 accessToken으로 저장한다.
+      type: 'linkedin',
+    };
+  }
+
+  /**
+   * 허가된 노션 페이지를 조회한다.
+   */
+  async getNotionAccessPages(accessToken: string): Promise<Array<NotionUtil.VerifyPageResponse>> {
+    const { apiVersion } = this.getNotionClient();
+
+    try {
+      const response = await axios.post(
+        `https://api.notion.com/v1/search`,
+        {
+          filter: {
+            value: 'page',
+            property: 'object',
+          },
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Notion-Version': apiVersion,
+          },
+        },
+      );
+
+      const page = response.data.results;
+
+      return page.map(
+        (el): NotionUtil.VerifyPageResponse => ({
+          id: el.id,
+          title: el.properties.title.title[0].plain_text,
+          url: el.url,
+        }),
+      );
+    } catch (error) {
+      throw new InternalServerErrorException(`노션 페이지 정보 읽어오기 실패.`);
+    }
+  }
+
+  /**
+   * google
+   *
+   * code를 구글 OAuth 토큰으로 교환한다. 유저 정보를 받아오는데에 사용한다.
+   */
+  private async getGoogleAccessToken(input: Auth.LoginRequest) {
+    const { clientId, clientSecret, redirectUri } = this.getGoogleClient();
+
+    const response = await axios.post<{
+      access_token: string;
+      refresh_token: string;
+      token_type: 'Bearer';
+      scope: string;
+      expires_in: number;
+    }>(`https://oauth2.googleapis.com/token`, {
+      code: input.code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: input.redirectUri ?? redirectUri,
+      grant_type: 'authorization_code',
+    });
+
+    return {
+      accessToken: response.data.access_token,
+      refreshToken: response.data.refresh_token,
+    };
+  }
+
+  /**
+   * google
+   *
+   * access token을 사용해 구글 유저 정보를 조회한다.
+   */
+  private async getGoogleUserInfo(accessToken: string) {
+    const response = await axios.get<{
+      id: string;
+      email: string;
+      verified_email: boolean;
+      name: string;
+      given_name: string;
+      family_name: string;
+      picture: string;
+    }>('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    return {
+      uid: response.data.id,
+      name: response.data.name,
+    };
+  }
+
+  /**
+   * notion
+   *
+   * code를 이용해 인증후 노션 사용자 정보를 받아온다.
+   */
+  private async getNotionAccessTokenAndUserinfo(input: Auth.LoginRequest) {
+    const { clientId, clientSecret, redirectUri } = this.getNotionClient();
+
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+    const response = await axios.post<NotionUtil.AuthorizationResponse>(
+      `https://api.notion.com/v1/oauth/token`,
+      {
+        grant_type: 'authorization_code',
+        code: input.code,
+        redirect_uri: input.redirectUri ?? redirectUri,
+      },
+      {
+        headers: {
+          Authorization: `Basic ${basicAuth}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return response.data;
+  }
+
+  /**
+   * github
+   *
+   * code를 이용해 깃허브 Access Token을 가져온다.
+   */
+  private async getGithubAccessToken(input: Auth.LoginRequest) {
+    const { clientId, clientSecret, redirectUri } = this.getGithubClient();
+
+    const response = await axios.post<{
+      access_token: string;
+      scope: string;
+      token_type: 'bearer';
+    }>(
+      `https://github.com/login/oauth/access_token`,
+      {
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: input.code,
+        redirect_uri: input.redirectUri ?? redirectUri,
+      },
+      {
+        headers: {
+          Accept: 'application/json',
+        },
+      },
+    );
+
+    return { accessToken: response.data.access_token };
+  }
+
+  /**
+   * github
+   *
+   * 깃허브 유저 데이터를 가져온다.
+   */
+  private async getGithubUserInfo(accessToken: string) {
+    const response = await axios.get<{
+      login: string;
+      id: number;
+      node_id: string;
+      avatar_url: string;
+      gravatar_id: string;
+      url: string;
+      html_url: string;
+      followers_url: string;
+      following_url: string;
+      gists_url: string;
+      starred_url: string;
+      subscriptions_url: string;
+      organizations_url: string;
+      repos_url: string;
+      events_url: string;
+      received_events_url: string;
+      type: string;
+      user_view_type: string;
+      site_admin: boolean;
+      name: string;
+      company: string | null;
+      blog: string;
+      location: string | null;
+      email: string | null;
+      hireable: boolean | null;
+      bio: string | null;
+      twitter_username: string | null;
+      notification_email: string | null;
+      public_repos: number;
+      public_gists: number;
+      followers: number;
+      following: number;
+      created_at: string;
+      updated_at: string;
+    }>('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    return { uid: `${response.data.id}`, name: response.data.name };
+  }
+
+  /**
+   * Linked-In
+   *
+   * code를 링크드인 OAuth 토큰으로 교환한다. 유저 정보를 받아오는데에 사용한다.
+   */
+  private async getLinkedinAccessToken(input: Auth.LoginRequest) {
+    const { clientId, clientSecret, redirectUri } = this.getLinkedinClient();
+
+    const response = await axios.post<{ access_token: string; expires_in: number; scope: string }>(
+      `https://www.linkedin.com/oauth/v2/accessToken`,
+      {
+        grant_type: 'authorization_code',
+        code: input.code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: input.redirectUri ?? redirectUri,
+      },
+      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+    );
+
+    return { accessToken: response.data.access_token };
+  }
+
+  /**
+   * Linked-In
+   *
+   * access token을 사용해 링크드인 유저 정보를 조회한다.
+   */
+  private async getLinkedinUserInfo(accessToken: string) {
+    const response = await axios.get<{
+      sub: string;
+      email_verified: boolean;
+      name: string;
+      locale: object;
+      given_name: string;
+      family_name: string;
+      email: string;
+    }>('https://api.linkedin.com/v2/userinfo', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return { uid: response.data.sub, name: response.data.name };
+  }
+
+  private getGoogleClient() {
+    return {
+      clientId: this.configService.get<string>('GOOGLE_CLIENT_ID'),
+      clientSecret: this.configService.get<string>('GOOGLE_CLIENT_SECRET'),
+      redirectUri: this.configService.get<string>('GOOGLE_REDIRECT_URI'),
+    };
+  }
+
+  private getNotionClient() {
+    return {
+      clientId: this.configService.get<string>('NOTION_CLIENT_ID'),
+      clientSecret: this.configService.get<string>('NOTION_CLIENT_SECRET'),
+      redirectUri: this.configService.get<string>('NOTION_REDIRECT_URI'),
+      apiVersion: this.configService.get<string>('NOTION_API_VERSION'),
+    };
+  }
+
+  private getGithubClient() {
+    return {
+      clientId: this.configService.get<string>('GITHUB_CLIENT_ID'),
+      clientSecret: this.configService.get<string>('GITHUB_CLIENT_SECRET'),
+      redirectUri: this.configService.get<string>('GITHUB_REDIRECT_URI'),
+    };
+  }
+
+  private getLinkedinClient() {
+    return {
+      clientId: this.configService.get<string>('LINKEDIN_CLIENT_ID'),
+      clientSecret: this.configService.get<string>('LINKEDIN_CLIENT_SECRET'),
+      redirectUri: this.configService.get<string>('LINKEDIN_REDIRECT_URI'),
+    };
+  }
+}


### PR DESCRIPTION
## OAuth 로그인 연동 기능을 추가합니다.

### 📌 관련 이슈

### ✏️ 변경 사항

1. OAuth 로그인 API 통합 및 추가됨

**- 이전 API**
```
GET /auth/google
GET /auth/github
GET /auth/linkedin
GET /auth/notion
GET /auth/google/callback
GET /auth/github/callback
GET /auth/linkedin/callback
GET /auth/notion/callback
```

**- 개선된 API** 
- 로그인 url 발급 API
- `:provider`를 동적으로 받아 하나의 엔드포인트에서 모든 OAuth 제공자를 처리할 수 있도록 변경
```
GET /auth/:provider
```

- 로그인 & 회원가입  API
```
GET /auth/:provider/callback
```
- callback에서 노션은 제외되었습니다. 아래 연동 기능으로 사용부탁드립니다.
```sh
GET /auth/notion/callback  # notion 로그인에 실패했습니다. 지원하는 로그인이 아닙니다.
```


**- 신규 API** 
- 로그인 연동 기능 API 추가
```
GET /auth/:provider/link
```