### PR TITLE
[Feat] Add dashboard

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { RoomsModule } from './modules/rooms.module';
 import { SkillsModule } from './modules/skills.module';
 import { SourcesModule } from './modules/sources.module';
 import { AdminModule } from './modules/admin.module';
+import { DashboardModule } from './modules/dashboard.module';
 
 @Module({
   imports: [
@@ -38,6 +39,7 @@ import { AdminModule } from './modules/admin.module';
     FileModule,
     MembersModule,
     AdminModule,
+    DashboardModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -1,7 +1,17 @@
+import core from '@nestia/core';
 import { Controller } from '@nestjs/common';
 import { DashboardService } from '../services/dashboard.service';
+import { Dashboard } from 'src/interfaces/dashboard.interface';
 
 @Controller('dashboard')
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
+
+  /**
+   * 랜딩 페이지용 통계데이터를 반환합니다.
+   */
+  @core.TypedRoute.Get()
+  async getDashboard(): Promise<Dashboard> {
+    return await this.dashboardService.get();
+  }
 }

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { DashboardService } from '../services/dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+}

--- a/src/interfaces/dashboard.interface.ts
+++ b/src/interfaces/dashboard.interface.ts
@@ -1,0 +1,5 @@
+export interface Dashboard {
+  characterCount: number;
+  roomCount: number;
+  chatCount: number;
+}

--- a/src/modules/dashboard.module.ts
+++ b/src/modules/dashboard.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DashboardService } from '../services/dashboard.service';
+import { DashboardController } from '../controllers/dashboard.controller';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -1,7 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
+import { Dashboard } from 'src/interfaces/dashboard.interface';
 
 @Injectable()
 export class DashboardService {
   constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 랜딩 페이지 통계데이터를 조회한다.
+   */
+  async get(): Promise<Dashboard> {
+    const characterCount = await this.prisma.character.count();
+    const roomCount = await this.prisma.room.count();
+    const chatCount = await this.prisma.chat.count();
+
+    return {
+      characterCount,
+      roomCount,
+      chatCount,
+    };
+  }
 }

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class DashboardService {
+  constructor(private readonly prisma: PrismaService) {}
+}


### PR DESCRIPTION
## 랜딩페이지 통계 API를 추가합니다.


### 📌 관련 이슈


### ✏️ 변경 사항

**1. `Get /dashboard` 통계 데이터 조회 API 추가 :**
- 랜딩페이지에 사용되는 통계 데이터를 반환합니다.
```ts
{
  characterCount: number; // 면접자 수 ( 캐릭터 수를 의미 )
  roomCount: number; // 전체 진행된 면접의 수 ( 캐릭터 대화방 수 )
  chatCount: number; // 진행된 대화 수 ( 말풍선의 수 )
}

```
