### PR TITLE
[Feat] Add Contact

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -163,7 +163,6 @@ erDiagram
   String message
   String status
   DateTime created_at
-  DateTime completed_at "nullable"
   DateTime deleted_at "nullable"
 }
 "Room" {
@@ -217,7 +216,7 @@ erDiagram
 **Properties**
   - `id`: PK
   - `member_id`: 가입된 사용자가 경력을 입력할 수 있다.
-  - `created_at`: 경력을 최초 입���후 저장한 시간.
+  - `created_at`: 경력을 최초 입력후 저장한 시간.
   - `deleted_at`: 경력을 삭제한 경우.
 
 ### `Experience_Snapshot`
@@ -367,12 +366,11 @@ React, NestJS 기술 스택(스킬)의 정보를 저장한다.
   - `message`: 연락 내용
   - `status`: 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
   - `created_at`: 연락하기 요청 시점
-  - `completed_at`: 발송 시점
   - `deleted_at`: 삭제 시점
 
 ### `Room`
 채팅방.
-하나의 캐릭터에 여러개의 유저가 채팅방을 생성할 수 있고, 유저는 여러개의 캐릭터에 대해 채팅방을 생성할 수 있다.
+하나의 캐릭터�� 여러개의 유저가 채팅방을 생성할 수 있고, 유저는 여러개의 캐릭터에 대해 채팅방을 생성할 수 있다.
 
 **Properties**
   - `id`: PK, 유저는 한 캐릭터에 대해서 여러 개의 방을 생성할 수 있기 때문에 별도의 ID를 둔다.

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -155,6 +155,17 @@ erDiagram
   DateTime created_at
   DateTime deleted_at "nullable"
 }
+"Contact" {
+  String id PK
+  String member_id FK
+  String character_id FK
+  String purpose
+  String message
+  String status
+  DateTime created_at
+  DateTime completed_at "nullable"
+  DateTime deleted_at "nullable"
+}
 "Room" {
   String id PK
   String user_id FK
@@ -192,6 +203,7 @@ erDiagram
 "Character_Snapshot_Position" }o--|| "Position" : postion
 "Character_Snapshot_Skill" }o--|| "Character_Snapshot" : character_snapshot
 "Character_Snapshot_Skill" }o--|| "Skill" : skill
+"Contact" }o--|| "Character" : character
 "Room" }o--|| "User" : user
 "Room" }o--|| "Character" : character
 "Chat" }o--|| "Room" : room
@@ -205,7 +217,7 @@ erDiagram
 **Properties**
   - `id`: PK
   - `member_id`: 가입된 사용자가 경력을 입력할 수 있다.
-  - `created_at`: 경력을 최초 입력후 저장한 시간.
+  - `created_at`: 경력을 최초 입���후 저장한 시간.
   - `deleted_at`: 경력을 삭제한 경우.
 
 ### `Experience_Snapshot`
@@ -342,6 +354,21 @@ React, NestJS 기술 스택(스킬)의 정보를 저장한다.
   - `keyword`: 스킬의 이름
   - `created_at`: 스킬이 등록된 시점
   - `deleted_at`: 스킬이 삭제된 시점
+
+### `Contact`
+연락
+연락하기 기능으로 요청된 메시지들을 저장한다.
+
+**Properties**
+  - `id`: PK
+  - `member_id`: 연락을 보낸 멤버의 아이디
+  - `character_id`: 연락을 받은 캐릭터의 아이디
+  - `purpose`: 어떤 목적으로 연락하는지 ( 커피챗, 면접 제안 등 유저 기입 )
+  - `message`: 연락 내용
+  - `status`: 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
+  - `created_at`: 연락하기 요청 시점
+  - `completed_at`: 발송 시점
+  - `deleted_at`: 삭제 시점
 
 ### `Room`
 채팅방.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -284,7 +284,6 @@ model Contact {
   message      String /// 연락 내용
   status       String /// 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
   created_at   DateTime  @db.Timestamptz /// 연락하기 요청 시점
-  completed_at DateTime? @db.Timestamptz /// 발송 시점
   deleted_at   DateTime? @db.Timestamptz /// 삭제 시점
 
   member    Member    @relation(fields: [member_id], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Member {
   providers   Provider[] /// 회원에 연결한 OAuth App들을 의미한다.
   characters  Character[] /// 회원이 생성한 캐릭터들.
   experiences Experience[] /// 회원과 연결된 경력 데이터를 의미한다.
+  contacts    Contact[] /// 회원이 보낸 연락들을 의미한다.
 }
 
 /// `Member`의 경력사항을 나타낸다.
@@ -276,13 +277,17 @@ model Skill {
 /// 연락하기 기능으로 요청된 메시지들을 저장한다.
 /// @namespace Character
 model Contact {
-  id           String   @id @db.Uuid /// PK
-  character_id String   @db.Uuid /// Charactor FK
+  id           String    @id @db.Uuid /// PK
+  member_id    String    @db.Uuid /// 연락을 보낸 멤버의 아이디
+  character_id String    @db.Uuid /// 연락을 받은 캐릭터의 아이디
   purpose      String ///  어떤 목적으로 연락하는지 ( 커피챗, 면접 제안 등 유저 기입 )
   message      String /// 연락 내용
   status       String /// 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
-  created_at   DateTime @db.Timestamptz /// 요청 시점
+  created_at   DateTime  @db.Timestamptz /// 연락하기 요청 시점
+  completed_at DateTime? @db.Timestamptz /// 발송 시점
+  deleted_at   DateTime? @db.Timestamptz /// 삭제 시점
 
+  member    Member    @relation(fields: [member_id], references: [id])
   character Character @relation(fields: [character_id], references: [id])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ model Character {
   chats                  Chat[] /// 캐릭터와 대화한 기록
   sources                Source[] /// 캐릭터 생성에 사용된 소스
   character_personalites Character_Personality[] /// 캐릭터 생성에 사용된 성격
+  contacts               Contact[] /// 해당 캐릭터에게 요청된 연락들
 
   /// 스냅샷들
   snapshots     Character_Snapshot[]
@@ -269,6 +270,20 @@ model Skill {
   deleted_at DateTime? @db.Timestamptz /// 스킬이 삭제된 시점
 
   character_snapshot_skills Character_Snapshot_Skill[]
+}
+
+/// 연락
+/// 연락하기 기능으로 요청된 메시지들을 저장한다.
+/// @namespace Character
+model Contact {
+  id           String   @id @db.Uuid /// PK
+  character_id String   @db.Uuid /// Charactor FK
+  purpose      String ///  어떤 목적으로 연락하는지 ( 커피챗, 면접 제안 등 유저 기입 )
+  message      String /// 연락 내용
+  status       String /// 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
+  created_at   DateTime @db.Timestamptz /// 요청 시점
+
+  character Character @relation(fields: [character_id], references: [id])
 }
 
 /// 채팅방.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { SkillsModule } from './modules/skills.module';
 import { SourcesModule } from './modules/sources.module';
 import { AdminModule } from './modules/admin.module';
 import { DashboardModule } from './modules/dashboard.module';
+import { ContactsModule } from './contacts/contacts.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { DashboardModule } from './modules/dashboard.module';
     MembersModule,
     AdminModule,
     DashboardModule,
+    ContactsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/contacts/contacts.module.ts
+++ b/src/contacts/contacts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ContactsController } from 'src/controllers/contacts.controller';
+import { ContactsService } from 'src/services/contacts.service';
+
+@Module({
+  controllers: [ContactsController],
+  providers: [ContactsService],
+})
+export class ContactsModule {}

--- a/src/contacts/contacts.module.ts
+++ b/src/contacts/contacts.module.ts
@@ -5,5 +5,6 @@ import { ContactsService } from 'src/services/contacts.service';
 @Module({
   controllers: [ContactsController],
   providers: [ContactsService],
+  exports: [ContactsService],
 })
 export class ContactsModule {}

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -83,7 +83,7 @@ export class AdminController {
   @core.TypedRoute.Patch('contacts/:id')
   async updateContactStatus(
     @core.TypedParam('id') id: Contacts['id'],
-    @core.TypedBody() body: Contacts.UpdateResponse,
+    @core.TypedBody() body: Contacts.UpdateRequest,
   ): Promise<Common.Response | Contacts.GetResponse> {
     const status = body.status;
     const contact = await this.contactsService.get(id);

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -4,10 +4,12 @@ import { ApiTags } from '@nestjs/swagger';
 import { AdminGuard } from 'src/guards/admin.guard';
 import { Character } from 'src/interfaces/characters.interface';
 import { Chat } from 'src/interfaces/chats.interface';
+import { Contacts } from 'src/interfaces/contacts.interface';
 import { Personality } from 'src/interfaces/personalities.interface';
 import { Room } from 'src/interfaces/rooms.interface';
 import { CharactersService } from 'src/services/characters.service';
 import { ChatsService } from 'src/services/chats.service';
+import { ContactsService } from 'src/services/contacts.service';
 import { PersonalitiesService } from 'src/services/personalities.service';
 import { RoomsService } from 'src/services/rooms.service';
 
@@ -20,6 +22,7 @@ export class AdminController {
     private readonly charactersService: CharactersService,
     private readonly roomsService: RoomsService,
     private readonly chatsService: ChatsService,
+    private readonly contactsService: ContactsService,
   ) {}
 
   /**
@@ -63,5 +66,13 @@ export class AdminController {
   @core.TypedRoute.Get('characters')
   async getCharacters(@core.TypedQuery() query: Character.GetByPageRequest): Promise<Character.GetByPageResponse> {
     return await this.charactersService.getBypage(query, { deletedAt: true });
+  }
+
+  /**
+   * 연락하기로 요청된 메시지를 조회한다.
+   */
+  @core.TypedRoute.Get('contacts')
+  async getContactsByPage(@core.TypedQuery() query: Contacts.GetByPageRequest): Promise<Contacts.GetByPageResponse> {
+    return await this.contactsService.getByPage(query);
   }
 }

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -1,9 +1,10 @@
 import core from '@nestia/core';
-import { Controller, UseGuards } from '@nestjs/common';
+import { Body, Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AdminGuard } from 'src/guards/admin.guard';
 import { Character } from 'src/interfaces/characters.interface';
 import { Chat } from 'src/interfaces/chats.interface';
+import { Common } from 'src/interfaces/common.interface';
 import { Contacts } from 'src/interfaces/contacts.interface';
 import { Personality } from 'src/interfaces/personalities.interface';
 import { Room } from 'src/interfaces/rooms.interface';
@@ -74,5 +75,23 @@ export class AdminController {
   @core.TypedRoute.Get('contacts')
   async getContactsByPage(@core.TypedQuery() query: Contacts.GetByPageRequest): Promise<Contacts.GetByPageResponse> {
     return await this.contactsService.getByPage(query);
+  }
+
+  /**
+   * 연락하기로 요청된 메시지를 조회한다.
+   */
+  @core.TypedRoute.Patch('contacts/:id')
+  async updateContactStatus(
+    @core.TypedParam('id') id: Contacts['id'],
+    @core.TypedBody() body: Contacts.UpdateResponse,
+  ): Promise<Common.Response | Contacts.GetResponse> {
+    const status = body.status;
+    const contact = await this.contactsService.get(id);
+
+    if (contact.status === status) {
+      return { message: `변경된 내용이 없습니다.` };
+    }
+
+    return await this.contactsService.updateStatus(id, status);
   }
 }

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -1,5 +1,5 @@
 import core from '@nestia/core';
-import { Body, Controller, UseGuards } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AdminGuard } from 'src/guards/admin.guard';
 import { Character } from 'src/interfaces/characters.interface';

--- a/src/controllers/contacts.controller.ts
+++ b/src/controllers/contacts.controller.ts
@@ -6,7 +6,6 @@ import { Character } from 'src/interfaces/characters.interface';
 import { Contacts } from 'src/interfaces/contacts.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { ContactsService } from 'src/services/contacts.service';
-import { PaginationUtil } from 'src/util/pagination.util';
 
 @Controller('contacts')
 export class ContactsController {

--- a/src/controllers/contacts.controller.ts
+++ b/src/controllers/contacts.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ContactsService } from 'src/services/contacts.service';
+
+@Controller('contacts')
+export class ContactsController {
+  constructor(private readonly contactsService: ContactsService) {}
+}

--- a/src/controllers/contacts.controller.ts
+++ b/src/controllers/contacts.controller.ts
@@ -1,7 +1,28 @@
-import { Controller } from '@nestjs/common';
+import core from '@nestia/core';
+import { Controller, UseGuards } from '@nestjs/common';
+import { Member } from 'src/decorators/member.decorator';
+import { MemberGuard } from 'src/guards/member.guard';
+import { Character } from 'src/interfaces/characters.interface';
+import { Contacts } from 'src/interfaces/contacts.interface';
+import { Guard } from 'src/interfaces/guard.interface';
 import { ContactsService } from 'src/services/contacts.service';
 
 @Controller('contacts')
 export class ContactsController {
   constructor(private readonly contactsService: ContactsService) {}
+
+  /**
+   * 연락하기 기능입니다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Post('/:characterId')
+  async createContact(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedParam('characterId') characterId: Character['id'],
+    @core.TypedBody() body: Contacts.CreateRequst,
+  ): Promise<Contacts.GetResponse> {
+    return this.contactsService.create(member.id, characterId, body);
+  }
 }

--- a/src/controllers/contacts.controller.ts
+++ b/src/controllers/contacts.controller.ts
@@ -6,6 +6,7 @@ import { Character } from 'src/interfaces/characters.interface';
 import { Contacts } from 'src/interfaces/contacts.interface';
 import { Guard } from 'src/interfaces/guard.interface';
 import { ContactsService } from 'src/services/contacts.service';
+import { PaginationUtil } from 'src/util/pagination.util';
 
 @Controller('contacts')
 export class ContactsController {
@@ -24,5 +25,19 @@ export class ContactsController {
     @core.TypedBody() body: Contacts.CreateRequst,
   ): Promise<Contacts.GetResponse> {
     return this.contactsService.create(member.id, characterId, body);
+  }
+
+  /**
+   * 연락하기 기능으로 작성한 메시지를 페이지네이션으로 조회합니다.
+   *
+   * @security x-member bearer
+   */
+  @UseGuards(MemberGuard)
+  @core.TypedRoute.Get('')
+  async getContactsByPage(
+    @Member() member: Guard.MemberResponse,
+    @core.TypedQuery() query: Contacts.GetByPageRequest,
+  ): Promise<Contacts.GetByPageResponse> {
+    return this.contactsService.getByPage(query, { memberId: member.id });
   }
 }

--- a/src/interfaces/contacts.interface.ts
+++ b/src/interfaces/contacts.interface.ts
@@ -42,5 +42,5 @@ export namespace Contacts {
   /**
    * 연락하기 상태 수정
    */
-  export interface UpdateResponse extends Pick<Contacts, 'status'> {}
+  export interface UpdateRequest extends Pick<Contacts, 'status'> {}
 }

--- a/src/interfaces/contacts.interface.ts
+++ b/src/interfaces/contacts.interface.ts
@@ -24,7 +24,14 @@ export namespace Contacts {
    */
   export interface GetByPageRequest extends PaginationUtil.Request {}
 
-  export interface GetByPageResponse extends PaginationUtil.Response<Contacts.GetResponse> {}
+  export interface GetByPageData extends Omit<Contacts.GetResponse, 'memberId'> {
+    member: {
+      id: Member['id'];
+      name: Member['name'];
+    };
+  }
+
+  export interface GetByPageResponse extends PaginationUtil.Response<Contacts.GetByPageData> {}
 
   /**
    * 연락하기 조회

--- a/src/interfaces/contacts.interface.ts
+++ b/src/interfaces/contacts.interface.ts
@@ -1,0 +1,26 @@
+import { tags } from 'typia';
+import { Character } from './characters.interface';
+import { Member } from './member.interface';
+
+export interface Contacts {
+  id: string & tags.Format<'uuid'>;
+  memberId: Member['id'];
+  characterId: Character['id'];
+  purpose: string & tags.MinLength<1>;
+  message: string & tags.MinLength<1>;
+  status: 'pending' | 'completed' | 'rejected';
+  createdAt: string & tags.Format<'date-time'>;
+}
+
+export namespace Contacts {
+  /**
+   * 연락하기 요청
+   */
+  export interface CreateRequst extends Pick<Contacts, 'purpose' | 'message'> {}
+
+  /**
+   * 연락하기 조회
+   */
+  export interface GetResponse
+    extends Pick<Contacts, 'id' | 'memberId' | 'characterId' | 'purpose' | 'message' | 'createdAt' | 'status'> {}
+}

--- a/src/interfaces/contacts.interface.ts
+++ b/src/interfaces/contacts.interface.ts
@@ -1,3 +1,4 @@
+import { PaginationUtil } from 'src/util/pagination.util';
 import { tags } from 'typia';
 import { Character } from './characters.interface';
 import { Member } from './member.interface';
@@ -17,6 +18,13 @@ export namespace Contacts {
    * 연락하기 요청
    */
   export interface CreateRequst extends Pick<Contacts, 'purpose' | 'message'> {}
+
+  /**
+   * 연락하기 페이지 조회
+   */
+  export interface GetByPageRequest extends PaginationUtil.Request {}
+
+  export interface GetByPageResponse extends PaginationUtil.Response<Contacts.GetResponse> {}
 
   /**
    * 연락하기 조회

--- a/src/interfaces/contacts.interface.ts
+++ b/src/interfaces/contacts.interface.ts
@@ -38,4 +38,9 @@ export namespace Contacts {
    */
   export interface GetResponse
     extends Pick<Contacts, 'id' | 'memberId' | 'characterId' | 'purpose' | 'message' | 'createdAt' | 'status'> {}
+
+  /**
+   * 연락하기 상태 수정
+   */
+  export interface UpdateResponse extends Pick<Contacts, 'status'> {}
 }

--- a/src/modules/admin.module.ts
+++ b/src/modules/admin.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ContactsModule } from 'src/contacts/contacts.module';
 import { AdminController } from 'src/controllers/admin.controller';
 import { AdminService } from '../services/admin.service';
 import { CharactersModule } from './characters.module';
@@ -7,7 +8,7 @@ import { PersonalitiesModule } from './personalities.module';
 import { RoomsModule } from './rooms.module';
 
 @Module({
-  imports: [PersonalitiesModule, CharactersModule, RoomsModule, ChatsModule],
+  imports: [PersonalitiesModule, CharactersModule, RoomsModule, ChatsModule, ContactsModule],
   controllers: [AdminController],
   providers: [AdminService],
 })

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ContactsService {}

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -7,8 +7,6 @@ import { Member } from 'src/interfaces/member.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
 import { PaginationUtil } from 'src/util/pagination.util';
 import { PrismaService } from './prisma.service';
-import { Guard } from 'src/interfaces/guard.interface';
-import { Format } from 'typia/lib/tags';
 
 @Injectable()
 export class ContactsService {

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -79,7 +79,12 @@ export class ContactsService {
       this.prisma.contact.findMany({
         select: {
           id: true,
-          member_id: true,
+          member: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
           character_id: true,
           purpose: true,
           message: true,
@@ -97,15 +102,18 @@ export class ContactsService {
     /**
      * mapping
      */
-    const data = contacts.map((el) => {
+    const data = contacts.map((el): Contacts.GetByPageData => {
       return {
         id: el.id,
-        memberId: el.member_id,
         characterId: el.character_id,
         purpose: el.purpose,
         message: el.message,
         status: el.status as Contacts['status'],
         createdAt: el.created_at.toISOString(),
+        member: {
+          id: el.member.id,
+          name: el.member.name,
+        },
       };
     });
 

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Character } from 'src/interfaces/characters.interface';
 import { Contacts } from 'src/interfaces/contacts.interface';
 import { Member } from 'src/interfaces/member.interface';
 import { DateTimeUtil } from 'src/util/date-time.util';
+import { PaginationUtil } from 'src/util/pagination.util';
 import { PrismaService } from './prisma.service';
 
 @Injectable()
@@ -51,5 +53,67 @@ export class ContactsService {
       status: contact.status as Contacts['status'],
       createdAt: contact.created_at.toISOString(),
     };
+  }
+
+  /**
+   * 연락하기 메시지를 페이지네이션으로 조회합니다.
+   *
+   * @param query 페이지네이션 요청 객체
+   * @param options 조회 옵셔널 파라미터들 입니다.
+   *
+   * - memberId: 특정 멤버가 보낸 메시지를 조회하고 싶다면, 멤버 아이디를 입력합니다.
+   */
+  async getByPage(
+    query: Contacts.GetByPageRequest,
+    options?: {
+      memberId?: Member['id'];
+    },
+  ): Promise<Contacts.GetByPageResponse> {
+    const { skip, take } = PaginationUtil.getOffset(query);
+
+    const whereInput: Prisma.ContactWhereInput = {
+      member_id: options?.memberId,
+    };
+
+    const [contacts, count] = await this.prisma.$transaction([
+      this.prisma.contact.findMany({
+        select: {
+          id: true,
+          member_id: true,
+          character_id: true,
+          purpose: true,
+          message: true,
+          status: true,
+          created_at: true,
+        },
+        orderBy: { created_at: 'desc' },
+        where: whereInput,
+        skip,
+        take,
+      }),
+      this.prisma.contact.count({ where: whereInput }),
+    ]);
+
+    /**
+     * mapping
+     */
+    const data = contacts.map((el) => {
+      return {
+        id: el.id,
+        memberId: el.member_id,
+        characterId: el.character_id,
+        purpose: el.purpose,
+        message: el.message,
+        status: el.status as Contacts['status'],
+        createdAt: el.created_at.toISOString(),
+      };
+    });
+
+    return PaginationUtil.createResponse({
+      data,
+      skip,
+      count,
+      take,
+    });
   }
 }

--- a/src/services/contacts.service.ts
+++ b/src/services/contacts.service.ts
@@ -1,4 +1,55 @@
 import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Character } from 'src/interfaces/characters.interface';
+import { Contacts } from 'src/interfaces/contacts.interface';
+import { Member } from 'src/interfaces/member.interface';
+import { DateTimeUtil } from 'src/util/date-time.util';
+import { PrismaService } from './prisma.service';
 
 @Injectable()
-export class ContactsService {}
+export class ContactsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * 연락하기 기능으로 요청된 메시지를 저장합니다.
+   */
+  async create(
+    memberId: Member['id'],
+    characterId: Character['id'],
+    body: Contacts.CreateRequst,
+  ): Promise<Contacts.GetResponse> {
+    const date = DateTimeUtil.now();
+    const status: Contacts['status'] = 'pending';
+
+    const contact = await this.prisma.contact.create({
+      select: {
+        id: true,
+        member_id: true,
+        character_id: true,
+        purpose: true,
+        message: true,
+        status: true,
+        created_at: true,
+      },
+      data: {
+        id: randomUUID(),
+        member_id: memberId,
+        character_id: characterId,
+        message: body.message,
+        purpose: body.purpose,
+        status: status,
+        created_at: date,
+      },
+    });
+
+    return {
+      id: contact.id,
+      memberId: contact.member_id,
+      characterId: contact.character_id,
+      purpose: contact.purpose,
+      message: contact.message,
+      status: contact.status as Contacts['status'],
+      createdAt: contact.created_at.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## 연락하기 기능을 추가합니다.
- 초기 기획안을 참고해, 정말 메시지를 저장하고 확인하는 기능 위주로만 구현되었습니다.


### 📌 관련 이슈


### ✏️ 변경 사항

0. `Contact` 테이블 스키마 추가
- 연락하기 기능으로 작성된 메시지를 저장하는 Contact 테이블이 추가되었습니다.
```prisma
/// 연락
/// 연락하기 기능으로 요청된 메시지들을 저장한다.
/// @namespace Character
model Contact {
  id           String    @id @db.Uuid /// PK
  member_id    String    @db.Uuid /// 연락을 보낸 멤버의 아이디
  character_id String    @db.Uuid /// 연락을 받은 캐릭터의 아이디
  purpose      String ///  어떤 목적으로 연락하는지 ( 커피챗, 면접 제안 등 유저 기입 )
  message      String /// 연락 내용
  status       String /// 처리 상태 (pending: 검토중/발송전, completed: 발송됨, rejected: 발송 거부됨)
  created_at   DateTime  @db.Timestamptz /// 연락하기 요청 시점
  deleted_at   DateTime? @db.Timestamptz /// 삭제 시점

  member    Member    @relation(fields: [member_id], references: [id])
  character Character @relation(fields: [character_id], references: [id])
}
```

**1. `Post /contact/:characterId` 연락하기 API**
- member 토큰이 필요한 기능(회원가입한 사용자만 사용가능)입니다. 특정 캐릭터에 대한 메시지를 작정합니다.
- 작성된 메시지는 관리자의 검토를 통해 전달될 예정입니다.

**2. `Get /contact/` 연락하기 메시지 페이지네이션 조회 API**
- 페이지네이션으로 보낸 메시지의 목록을 확인합니다. 로그인 한 사용자의 메시지만 노출됩니다.
- 기본값은 1 페이지 10개이며, 최신순으로 정렬됩니다. 

**3. `Get /admin/contact` 어드민 용 연락하기 메시지 페이지네이션 조회 API** 
- 어드민용 API 입니다. 모든 사용자가 작성한 메시지가 노출됩니다. 
- 멤버용과 동일하게 최신순으로 정렬됩니다.

**4. `Patch /admin/:id` 어드민 용 연락하기 컨펌 API**
- 어드민용 API 입니다. 메시지의 상태를 변경합니다. 변경할 수 있는 상태는 다음과 같습니다.
```ts
export interface UpdateRequest  {
  status: 'pending'    // 검토 대기중
          | 'completed'  // 검토 완료
          | 'rejected';     // 반려됨
}
```
